### PR TITLE
Improve FFmpeg error reporting

### DIFF
--- a/GifProcessor.cs
+++ b/GifProcessor.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 using FFMpegCore;
+using FFMpegCore.Exceptions;
 using ImageMagick;
 
 namespace GifProcessorApp
@@ -1081,9 +1082,9 @@ namespace GifProcessorApp
                     // Capture detailed FFmpeg output if available
                     string ffmpegOutput = null;
                     string logFilePath = null;
-                    if (ex is FFMpegException ffmpegException && !string.IsNullOrWhiteSpace(ffmpegException.Output))
+                    if (ex is FFMpegException ffmpegException && !string.IsNullOrWhiteSpace(ffmpegException.FFMpegErrorOutput))
                     {
-                        ffmpegOutput = ffmpegException.Output;
+                        ffmpegOutput = ffmpegException.FFMpegErrorOutput;
                         try
                         {
                             string logDirectory = Path.GetDirectoryName(outputPath);


### PR DESCRIPTION
## Summary
- Capture `FFMpegException` output during MP4-to-GIF conversion and persist stderr to a log file when available
- Append truncated FFmpeg stderr or log path to user-facing error messages for faster troubleshooting

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found, likely due to missing Windows Desktop SDK)*

------
https://chatgpt.com/codex/tasks/task_e_68b06cedc3b48330933599cba481502a