### PR TITLE
Log FFmpeg output when GPU decode fails

### DIFF
--- a/GifProcessor.cs
+++ b/GifProcessor.cs
@@ -1067,10 +1067,26 @@ namespace GifProcessorApp
                             mainForm.lblStatus.Text = "GPU decode failed, using CPU...";
                             Application.DoEvents();
 
-                            if (gpuEx is FFMpegException ffmpegEx && !string.IsNullOrWhiteSpace(ffmpegEx.FFMpegErrorOutput))
+                            if (gpuEx is FFMpegException ffmpegException && !string.IsNullOrWhiteSpace(ffmpegException.FFMpegErrorOutput))
                             {
-                                MessageBox.Show($"FFmpeg GPU error output:\n{ffmpegEx.FFMpegErrorOutput}",
-                                                "GPU Decode Error", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                                string logFilePath = null;
+                                try
+                                {
+                                    string logDirectory = Path.GetDirectoryName(outputPath);
+                                    if (string.IsNullOrEmpty(logDirectory) || !Directory.Exists(logDirectory))
+                                        logDirectory = Path.GetTempPath();
+
+                                    logFilePath = Path.Combine(logDirectory, "ffmpeg_gpu_error.log");
+                                    File.WriteAllText(logFilePath, ffmpegException.FFMpegErrorOutput);
+                                    mainForm.lblStatus.Text += $" (FFmpeg log: {logFilePath})";
+                                }
+                                catch
+                                {
+                                    string truncated = ffmpegException.FFMpegErrorOutput.Length > 200
+                                        ? ffmpegException.FFMpegErrorOutput.Substring(0, 200) + "..."
+                                        : ffmpegException.FFMpegErrorOutput;
+                                    mainForm.lblStatus.Text += $" FFmpeg output: {truncated}";
+                                }
                             }
 
                             // GPU failed, fallback to full CPU processing


### PR DESCRIPTION
## Summary
- log FFmpeg GPU error output to a file and mention it in the status label before falling back to CPU processing

## Testing
- `dotnet build SteamGifCropper.sln` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b076804bc08330a2a812a53a4a4844