### PR TITLE
Add unit tests for GifProcessor

### DIFF
--- a/SteamGifCropper.Tests/GifProcessorTests.cs
+++ b/SteamGifCropper.Tests/GifProcessorTests.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Reflection;
+using System.Collections.Generic;
+using GifProcessorApp;
+
+namespace SteamGifCropper.Tests;
+
+public class GifProcessorTests
+{
+    private static MethodInfo GetMethod(string name) =>
+        typeof(GifProcessor).GetMethod(name, BindingFlags.NonPublic | BindingFlags.Static) ??
+        throw new InvalidOperationException($"Method '{name}' not found.");
+
+    public static IEnumerable<object[]> CanvasWidthData => new[]
+    {
+        new object[] { (uint)766, true },
+        new object[] { (uint)774, true },
+        new object[] { (uint)760, false },
+        new object[] { (uint)0, false }
+    };
+
+    [Theory]
+    [MemberData(nameof(CanvasWidthData))]
+    public void IsValidCanvasWidth_ReturnsExpected(uint width, bool expected)
+    {
+        var method = GetMethod("IsValidCanvasWidth");
+        bool result = (bool)method.Invoke(null, new object?[] { width })!;
+        Assert.Equal(expected, result);
+    }
+
+    public static IEnumerable<object[]> CropRangeData => new[]
+    {
+        new object[]
+        {
+            (uint)766,
+            new (int Start, int End)[]
+            {
+                (0, 149),
+                (154, 303),
+                (308, 457),
+                (462, 611),
+                (616, 765)
+            }
+        },
+        new object[]
+        {
+            (uint)774,
+            new (int Start, int End)[]
+            {
+                (0, 149),
+                (155, 305),
+                (311, 461),
+                (467, 617),
+                (623, 773)
+            }
+        }
+    };
+
+    [Theory]
+    [MemberData(nameof(CropRangeData))]
+    public void GetCropRanges_ReturnsExpected(uint width, (int Start, int End)[] expected)
+    {
+        var method = GetMethod("GetCropRanges");
+        var result = ((int Start, int End)[])method.Invoke(null, new object?[] { width })!;
+        Assert.Equal(expected, result);
+    }
+}
+

--- a/SteamGifCropper.Tests/GlobalUsings.cs
+++ b/SteamGifCropper.Tests/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/SteamGifCropper.Tests/SteamGifCropper.Tests.csproj
+++ b/SteamGifCropper.Tests/SteamGifCropper.Tests.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\SteamGifCropper.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/SteamGifCropper.csproj
+++ b/SteamGifCropper.csproj
@@ -55,6 +55,11 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Remove="SteamGifCropper.Tests/**" />
+    <None Remove="SteamGifCropper.Tests/**" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Content Include="icon.ico" />
     <None Include="app.manifest" />
     <Content Include="arrange.html">

--- a/SteamGifCropper.sln
+++ b/SteamGifCropper.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 17.12.35527.113 d17.12
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SteamGifCropper", "SteamGifCropper.csproj", "{336D2573-022A-4DBB-A448-7370D4BDD9F8}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SteamGifCropper.Tests", "SteamGifCropper.Tests\SteamGifCropper.Tests.csproj", "{31A9AC41-7CC0-480A-832C-0138EEE3D862}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -15,6 +17,10 @@ Global
 		{336D2573-022A-4DBB-A448-7370D4BDD9F8}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{336D2573-022A-4DBB-A448-7370D4BDD9F8}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{336D2573-022A-4DBB-A448-7370D4BDD9F8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{31A9AC41-7CC0-480A-832C-0138EEE3D862}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{31A9AC41-7CC0-480A-832C-0138EEE3D862}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{31A9AC41-7CC0-480A-832C-0138EEE3D862}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{31A9AC41-7CC0-480A-832C-0138EEE3D862}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
## Summary
- add xUnit test project targeting GifProcessor
- verify IsValidCanvasWidth accepts only supported widths
- test GetCropRanges returns correct tuples for supported widths

## Testing
- `dotnet test` *(fails: Microsoft.WindowsDesktop.App runtime not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1becfc54c833087e7cdba792d5e46