### PR TITLE
Annotate nullable references to resolve warnings

### DIFF
--- a/GifsicleWrapper.cs
+++ b/GifsicleWrapper.cs
@@ -25,7 +25,7 @@ public class GifsicleWrapper
         return (output, error);
     }
 
-    public static void OptimizeGif(string inputPath, string outputPath, GifsicleOptions options = null)
+    public static void OptimizeGif(string inputPath, string outputPath, GifsicleOptions? options = null)
     {
         if (options == null) options = new GifsicleOptions();
 

--- a/RegistryProvider.cs
+++ b/RegistryProvider.cs
@@ -1,5 +1,7 @@
 using Microsoft.Win32;
 
+#nullable enable
+
 namespace GifProcessorApp;
 
 public interface IRegistryProvider

--- a/WindowsThemeManager.cs
+++ b/WindowsThemeManager.cs
@@ -3,6 +3,8 @@ using System.Drawing;
 using System.Runtime.InteropServices;
 using System.Windows.Forms;
 
+#nullable enable
+
 namespace GifProcessorApp
 {
     public static class WindowsThemeManager
@@ -14,7 +16,7 @@ namespace GifProcessorApp
         private static extern int DwmSetWindowAttribute(IntPtr hwnd, int attr, ref int attrValue, int attrSize);
 
         [DllImport("uxtheme.dll", CharSet = CharSet.Unicode)]
-        private static extern int SetWindowTheme(IntPtr hwnd, string pszSubAppName, string pszSubIdList);
+        private static extern int SetWindowTheme(IntPtr hwnd, string? pszSubAppName, string? pszSubIdList);
 
         public static bool IsDarkModeEnabled(IRegistryProvider? registryProvider = null)
         {


### PR DESCRIPTION
## Summary
- Allow null default for GIF optimizer options
- Enable nullable reference context for registry provider
- Support null window theme strings and enable nullable context

## Testing
- `dotnet test` *(fails: The imported project "Microsoft.NET.Sdk.WindowsDesktop.targets" was not found; and 1 test failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b23ea9d92083309f3ee4da4a0335cc