### PR TITLE
Enable nullable context for GifsicleWrapper

### DIFF
--- a/GifsicleWrapper.cs
+++ b/GifsicleWrapper.cs
@@ -3,6 +3,8 @@ using System.Diagnostics;
 using System.IO;
 using System.Text;
 
+#nullable enable
+
 public class GifsicleWrapper
 {
     public class GifsicleOptions


### PR DESCRIPTION
## Summary
- enable nullable annotations in `GifsicleWrapper`
- allow optional `GifsicleOptions` parameter without compiler warnings

## Testing
- `dotnet test` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found; 1 failing test)*

------
https://chatgpt.com/codex/tasks/task_e_68b241352f688330bec77a09bd768ff8