### PR TITLE
Fix DPI handling for main form

### DIFF
--- a/GTMainForm.Designer.cs
+++ b/GTMainForm.Designer.cs
@@ -397,7 +397,8 @@
             // 
             AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
             AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
-            AutoSize = true;
+            AutoSize = false;
+            AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
             ClientSize = new System.Drawing.Size(586, 444);
             Controls.Add(chk5GIFMergeFasterPaletteProcess);
             Controls.Add(panelGifsicle);

--- a/GTMainForm.cs
+++ b/GTMainForm.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Drawing;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 using Microsoft.Win32;
@@ -73,6 +74,14 @@ namespace GifProcessorApp
         {
             SystemEvents.UserPreferenceChanged -= SystemEvents_UserPreferenceChanged;
             base.OnHandleDestroyed(e);
+        }
+
+        protected override void OnDpiChanged(DpiChangedEventArgs e)
+        {
+            base.OnDpiChanged(e);
+            Bounds = e.SuggestedRectangle;
+            AutoScaleDimensions = new SizeF(e.DeviceDpiNew, e.DeviceDpiNew);
+            PerformLayout();
         }
 
         private async Task ExecuteWithErrorHandling(Func<Task> action, string operationName)


### PR DESCRIPTION
## Summary
- Disable automatic form resizing and fix initial size
- Handle DPI changes by updating bounds and layout

## Testing
- `dotnet test` *(fails: Unsupported width: 1920)*

------
https://chatgpt.com/codex/tasks/task_e_68b2765c6d988330a72c52491258a552