### PR TITLE
Refactor GIF merging palette usage

### DIFF
--- a/GifProcessor.cs
+++ b/GifProcessor.cs
@@ -603,7 +603,7 @@ namespace GifProcessorApp
                     DitherMethod = useFastPalette ? DitherMethod.No : DitherMethod.FloydSteinberg
                 };
 
-                foreach (var frame in mergedCollection)
+                foreach (MagickImage frame in mergedCollection)
                 {
                     frame.Map(palette, mapSettings);
                 }
@@ -1220,7 +1220,7 @@ namespace GifProcessorApp
                         DitherMethod = useFastPalette ? DitherMethod.No : DitherMethod.FloydSteinberg
                     };
 
-                    foreach (var frame in mergedCollection)
+                    foreach (MagickImage frame in mergedCollection)
                     {
                         frame.Map(palette, mapSettings);
                     }

--- a/GifProcessor.cs
+++ b/GifProcessor.cs
@@ -508,7 +508,7 @@ namespace GifProcessorApp
                 {
                     if (c != null && c.Count > 0)
                     {
-                        paletteSamples.Add(c[0]);
+                        paletteSamples.Add((MagickImage)c[0].Clone());
                     }
                 }
 
@@ -605,7 +605,7 @@ namespace GifProcessorApp
 
                 foreach (MagickImage frame in mergedCollection)
                 {
-                    frame.Map(palette, mapSettings);
+                    frame.Remap(palette, mapSettings);
                 }
                 palette.Dispose();
 
@@ -1222,7 +1222,7 @@ namespace GifProcessorApp
 
                     foreach (MagickImage frame in mergedCollection)
                     {
-                        frame.Map(palette, mapSettings);
+                        frame.Remap(palette, mapSettings);
                     }
 
                     // Apply LZW compression

--- a/GifProcessor.cs
+++ b/GifProcessor.cs
@@ -526,7 +526,8 @@ namespace GifProcessorApp
 
                 paletteSamples.Quantize(settings);
 
-                return paletteSamples[0].Clone();
+                // Create a copy of the quantized sample to use as palette
+                return new MagickImage(paletteSamples[0]);
             }
             finally
             {
@@ -602,7 +603,10 @@ namespace GifProcessorApp
                     DitherMethod = useFastPalette ? DitherMethod.No : DitherMethod.FloydSteinberg
                 };
 
-                mergedCollection.Map(palette, mapSettings);
+                foreach (var frame in mergedCollection)
+                {
+                    frame.Map(palette, mapSettings);
+                }
                 palette.Dispose();
 
                 return mergedCollection;
@@ -1216,7 +1220,10 @@ namespace GifProcessorApp
                         DitherMethod = useFastPalette ? DitherMethod.No : DitherMethod.FloydSteinberg
                     };
 
-                    mergedCollection.Map(palette, mapSettings);
+                    foreach (var frame in mergedCollection)
+                    {
+                        frame.Map(palette, mapSettings);
+                    }
 
                     // Apply LZW compression
                     foreach (var frame in mergedCollection)


### PR DESCRIPTION
## Summary
- Build a shared palette from sample frames and map merged GIF frames to it
- Support fast or quality palette processing controlled by merge options

## Testing
- `dotnet test` *(fails: Unsupported width: 1920)*

------
https://chatgpt.com/codex/tasks/task_e_68b286c763a48330bd24fb2a98cfcc45