### PR TITLE
Add comprehensive GIF merging tests

### DIFF
--- a/SteamGifCropper.Tests/GifProcessorMagickTests.cs
+++ b/SteamGifCropper.Tests/GifProcessorMagickTests.cs
@@ -33,9 +33,8 @@ public class GifProcessorMagickTests
     [Fact]
     public void SplitGif_CreatesFivePartsWithCorrectWidth()
     {
-        string input = Path.Combine("TestData", "wide.gif");
-        bool created = EnsureGif(input, 766, 100);
         string tempDir = Directory.CreateTempSubdirectory().FullName;
+        string input = GifTestHelper.CreateGradientGif(tempDir, 766, 100, 1, "red", "black");
         try
         {
             GifProcessor.SplitGif(input, tempDir);
@@ -50,10 +49,6 @@ public class GifProcessorMagickTests
         finally
         {
             Directory.Delete(tempDir, true);
-            if (created)
-            {
-                //File.Delete(input);  // keep source file
-            }
         }
     }
 

--- a/SteamGifCropper.Tests/GifTestHelper.cs
+++ b/SteamGifCropper.Tests/GifTestHelper.cs
@@ -1,0 +1,24 @@
+using System;
+using System.IO;
+using ImageMagick;
+
+namespace SteamGifCropper.Tests;
+
+internal static class GifTestHelper
+{
+    public static string CreateGradientGif(string directory, int width, int height, int frames, string startColor, string endColor)
+    {
+        string path = Path.Combine(directory, Guid.NewGuid().ToString() + ".gif");
+        using var collection = new MagickImageCollection();
+        for (int i = 0; i < frames; i++)
+        {
+            var settings = new MagickReadSettings { Width = (uint)width, Height = (uint)height };
+            var image = new MagickImage($"gradient:{startColor}-{endColor}", settings);
+            image.AnimationDelay = 10;
+            image.AnimationTicksPerSecond = 100;
+            collection.Add(image);
+        }
+        collection.Write(path);
+        return path;
+    }
+}

--- a/SteamGifCropper.Tests/GifToolMainForm.Stub.cs
+++ b/SteamGifCropper.Tests/GifToolMainForm.Stub.cs
@@ -1,0 +1,12 @@
+namespace GifProcessorApp;
+
+public class GifToolMainForm
+{
+    public Label lblStatus { get; } = new();
+
+    public class Label
+    {
+        public string Text { get; set; } = string.Empty;
+    }
+}
+

--- a/SteamGifCropper.Tests/MergeGifTests.cs
+++ b/SteamGifCropper.Tests/MergeGifTests.cs
@@ -1,0 +1,109 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using GifProcessorApp;
+using ImageMagick;
+using Xunit;
+
+namespace SteamGifCropper.Tests;
+
+public class MergeGifTests
+{
+    public static IEnumerable<object[]> GifCounts => new[]
+    {
+        new object[] { 2 },
+        new object[] { 3 },
+        new object[] { 4 },
+        new object[] { 5 }
+    };
+
+    [Theory]
+    [MemberData(nameof(GifCounts))]
+    public async Task MergeMultipleGifs_MergesCorrectly(int gifCount)
+    {
+        string tempDir = Directory.CreateTempSubdirectory().FullName;
+        try
+        {
+            int[] widths = { 20, 30, 40, 50, 60 };
+            int[] frames = { 4, 3, 2, 5, 6 };
+            string[] colors = { "red", "green", "blue", "yellow", "purple" };
+            var gifPaths = new List<string>();
+            for (int i = 0; i < gifCount; i++)
+            {
+                gifPaths.Add(GifTestHelper.CreateGradientGif(tempDir, widths[i], 20, frames[i], colors[i], "black"));
+            }
+
+            var form = new GifToolMainForm();
+            int targetFramerate = 10;
+
+            string fastOutput = Path.Combine(tempDir, "merged_fast.gif");
+            await GifProcessor.MergeMultipleGifs(gifPaths, fastOutput, form, targetFramerate, true);
+            using var fast = new MagickImageCollection(fastOutput);
+            Assert.Equal(widths.Take(gifCount).Sum(), (int)fast[0].Width);
+            Assert.Equal(frames.Take(gifCount).Min(), fast.Count);
+            int fastColors = (int)fast[0].TotalColors;
+            Assert.True(fastColors <= 256);
+
+            string qualityOutput = Path.Combine(tempDir, "merged_quality.gif");
+            await GifProcessor.MergeMultipleGifs(gifPaths, qualityOutput, form, targetFramerate, false);
+            using var quality = new MagickImageCollection(qualityOutput);
+            Assert.Equal(widths.Take(gifCount).Sum(), (int)quality[0].Width);
+            Assert.Equal(frames.Take(gifCount).Min(), quality.Count);
+            int qualityColors = (int)quality[0].TotalColors;
+            Assert.True(qualityColors <= 256);
+
+            Assert.NotEqual(fastColors, qualityColors);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void MergeGifsHorizontally_SplitsCorrectlyAndReusesPalette()
+    {
+        string tempDir = Directory.CreateTempSubdirectory().FullName;
+        try
+        {
+            int[] widths = { 153, 153, 154, 153, 153 };
+            string[] colors = { "red", "green", "blue", "yellow", "purple" };
+            int height = 50;
+            var paths = new List<string>();
+            for (int i = 0; i < 5; i++)
+            {
+                paths.Add(GifTestHelper.CreateGradientGif(tempDir, widths[i], height, 2, colors[i], "black"));
+            }
+
+            var collections = paths.Select(p => new MagickImageCollection(p)).ToArray();
+            foreach (var c in collections) c.Coalesce();
+
+            GifProcessor.PaletteQuantizeCallCount = 0;
+            var form = new GifToolMainForm();
+            var method = typeof(GifProcessor).GetMethod("MergeGifsHorizontally", BindingFlags.NonPublic | BindingFlags.Static)!;
+            using var merged = (MagickImageCollection)method.Invoke(null, new object?[] { collections, form, false })!;
+            Assert.Equal(766U, merged[0].Width);
+
+            string mergedPath = Path.Combine(tempDir, "merged.gif");
+            merged.Write(mergedPath);
+            GifProcessor.SplitGif(mergedPath, tempDir);
+            var files = Directory.GetFiles(tempDir, "*_Part*.gif");
+            Assert.Equal(5, files.Length);
+            foreach (var file in files)
+            {
+                using var img = new MagickImage(file);
+                Assert.Equal(150U, img.Width);
+                Assert.Equal((uint)(height + 100), img.Height);
+            }
+
+            Assert.Equal(1, GifProcessor.PaletteQuantizeCallCount);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add tests for merging multiple GIFs verifying output dimensions, frame counts, and palette differences
- Add horizontal merge tests ensuring split widths, adjusted heights, and palette reuse
- Provide helper stubs for GIF creation and minimal main form

## Testing
- `dotnet test SteamGifCropper.Tests/SteamGifCropper.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68b29694e13083309f81a4307cfc271e