### PR TITLE
Add language switch handlers for context menu

### DIFF
--- a/GTMainForm.Designer.cs
+++ b/GTMainForm.Designer.cs
@@ -432,21 +432,24 @@
             toolStripLangEnglish.Name = "toolStripLangEnglish";
             toolStripLangEnglish.Size = new System.Drawing.Size(180, 22);
             toolStripLangEnglish.Text = "English";
-            // 
+            toolStripLangEnglish.Click += toolStripLangEnglish_Click;
+            //
             // toolStripLangTradChinese
-            // 
+            //
             toolStripLangTradChinese.Name = "toolStripLangTradChinese";
             toolStripLangTradChinese.Size = new System.Drawing.Size(180, 22);
             toolStripLangTradChinese.Text = "繁體中文";
-            // 
+            toolStripLangTradChinese.Click += toolStripLangTradChinese_Click;
+            //
             // toolStripLangJapanese
-            // 
+            //
             toolStripLangJapanese.Name = "toolStripLangJapanese";
             toolStripLangJapanese.Size = new System.Drawing.Size(180, 22);
             toolStripLangJapanese.Text = "日本語";
-            // 
+            toolStripLangJapanese.Click += toolStripLangJapanese_Click;
+            //
             // GifToolMainForm
-            // 
+            //
             AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
             AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;

--- a/GTMainForm.cs
+++ b/GTMainForm.cs
@@ -241,5 +241,23 @@ namespace GifProcessorApp
         {
             conMenuLangSwitch.Show(btnLanguageChange, new Point(0, btnLanguageChange.Height));
         }
+
+        private void toolStripLangEnglish_Click(object sender, EventArgs e)
+        {
+            SwitchLanguage("en");
+            conMenuLangSwitch.Close();
+        }
+
+        private void toolStripLangTradChinese_Click(object sender, EventArgs e)
+        {
+            SwitchLanguage("zh-TW");
+            conMenuLangSwitch.Close();
+        }
+
+        private void toolStripLangJapanese_Click(object sender, EventArgs e)
+        {
+            SwitchLanguage("ja");
+            conMenuLangSwitch.Close();
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Wire up language menu items to call SwitchLanguage for English, Traditional Chinese, and Japanese
- Close language selection menu after language changes

## Testing
- `dotnet test` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found but tests still executed and passed)*

------
https://chatgpt.com/codex/tasks/task_e_68b2af82a9a883308a45c8e0ad0e9005