### PR TITLE
Theme language context menu

### DIFF
--- a/GTMainForm.cs
+++ b/GTMainForm.cs
@@ -62,6 +62,7 @@ namespace GifProcessorApp
             try
             {
                 WindowsThemeManager.ApplyThemeToControl(this, _isDarkMode);
+                WindowsThemeManager.ApplyThemeToControl(conMenuLangSwitch, _isDarkMode);
                 this.Refresh();
             }
             catch (Exception ex)

--- a/WindowsThemeManager.cs
+++ b/WindowsThemeManager.cs
@@ -83,19 +83,38 @@ namespace GifProcessorApp
 
         public static void ApplyThemeToControl(Control control, bool isDarkMode)
         {
-            if (isDarkMode)
+            if (control is ContextMenuStrip contextMenu)
             {
-                ApplyDarkTheme(control);
+                if (isDarkMode)
+                {
+                    ApplyDarkTheme(contextMenu);
+                }
+                else
+                {
+                    ApplyLightTheme(contextMenu);
+                }
+
+                foreach (ToolStripItem item in contextMenu.Items)
+                {
+                    ApplyThemeToToolStripItem(item, isDarkMode);
+                }
             }
             else
             {
-                ApplyLightTheme(control);
-            }
+                if (isDarkMode)
+                {
+                    ApplyDarkTheme(control);
+                }
+                else
+                {
+                    ApplyLightTheme(control);
+                }
 
-            // Recursively apply to child controls
-            foreach (Control childControl in control.Controls)
-            {
-                ApplyThemeToControl(childControl, isDarkMode);
+                // Recursively apply to child controls
+                foreach (Control childControl in control.Controls)
+                {
+                    ApplyThemeToControl(childControl, isDarkMode);
+                }
             }
         }
 
@@ -161,6 +180,15 @@ namespace GifProcessorApp
                 case GroupBox groupBox:
                     groupBox.BackColor = Color.Transparent;
                     groupBox.ForeColor = darkForeColor;
+                    break;
+
+                case ContextMenuStrip menu:
+                    menu.BackColor = darkControlColor;
+                    menu.ForeColor = darkForeColor;
+                    foreach (ToolStripItem item in menu.Items)
+                    {
+                        ApplyThemeToToolStripItem(item, true);
+                    }
                     break;
 
                 default:
@@ -231,10 +259,41 @@ namespace GifProcessorApp
                     groupBox.ForeColor = SystemColors.ControlText;
                     break;
 
+                case ContextMenuStrip menu:
+                    menu.BackColor = SystemColors.Control;
+                    menu.ForeColor = SystemColors.ControlText;
+                    foreach (ToolStripItem item in menu.Items)
+                    {
+                        ApplyThemeToToolStripItem(item, false);
+                    }
+                    break;
+
                 default:
                     control.BackColor = SystemColors.Control;
                     control.ForeColor = SystemColors.ControlText;
                     break;
+            }
+        }
+
+        private static void ApplyThemeToToolStripItem(ToolStripItem item, bool isDarkMode)
+        {
+            if (isDarkMode)
+            {
+                item.BackColor = Color.FromArgb(45, 45, 48);
+                item.ForeColor = Color.FromArgb(255, 255, 255);
+            }
+            else
+            {
+                item.BackColor = SystemColors.Control;
+                item.ForeColor = SystemColors.ControlText;
+            }
+
+            if (item is ToolStripMenuItem menuItem && menuItem.HasDropDownItems)
+            {
+                foreach (ToolStripItem dropDownItem in menuItem.DropDownItems)
+                {
+                    ApplyThemeToToolStripItem(dropDownItem, isDarkMode);
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- Theme the language switch context menu alongside the main form
- Allow WindowsThemeManager to style ContextMenuStrips and their items for dark and light modes

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-8.0` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b2b3e423dc8330a7d495d32d952926