### PR TITLE
Use localized resource for gifsicle notice label

### DIFF
--- a/GTMainForm.Designer.cs
+++ b/GTMainForm.Designer.cs
@@ -314,7 +314,7 @@
             label1.Name = "label1";
             label1.Size = new System.Drawing.Size(255, 15);
             label1.TabIndex = 12;
-            label1.Text = "Notice: gifsicle.exe must be in \"System Path\"";
+            label1.Text = SteamGifCropper.Properties.Resources.Label_GifsicleNotice;
             // 
             // chkGifsicle
             // 

--- a/Properties/Resources.ja.resx
+++ b/Properties/Resources.ja.resx
@@ -477,7 +477,7 @@
     <value>gifsicle最適化を有効にする</value>
   </data>
   <data name="Label_GifsicleNotice" xml:space="preserve">
-    <value>注意：gifsicle.exeは「システムパス "PATH"」にある必要があります</value>
+    <value>注意：gifsicle.exe は「システム PATH」に存在する必要があります</value>
   </data>
   <data name="MergeDialog_Instructions" xml:space="preserve">
     <value>マージする2-5個のGIFファイルを選択してください（左から右の順序で）：</value>
@@ -609,6 +609,6 @@ Windows パッケージマネージャを使用した簡単なインストール
   </data>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="lang_switch" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>C:\Users\Andyc\Downloads\lang_switch.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+    <value>..\Resources\lang_switch.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
 </root>

--- a/Properties/Resources.resx
+++ b/Properties/Resources.resx
@@ -469,7 +469,7 @@
     <value>Enable gifsicle optimization</value>
   </data>
   <data name="Label_GifsicleNotice" xml:space="preserve">
-    <value>Notice: gifsicle.exe must be in "System Path"</value>
+    <value>Notice: gifsicle.exe must be in the "System PATH"</value>
   </data>
   <data name="MergeDialog_Instructions" xml:space="preserve">
     <value>Please select 2-5 GIF files to merge (in order from left to right):</value>

--- a/Properties/Resources.zh-TW.resx
+++ b/Properties/Resources.zh-TW.resx
@@ -477,7 +477,7 @@
     <value>啟用gifsicle最佳化</value>
   </data>
   <data name="Label_GifsicleNotice" xml:space="preserve">
-    <value>注意：gifsicle.exe必須在「系統路徑變數 PATH」中</value>
+    <value>注意：gifsicle.exe 必須位於「系統 PATH」中</value>
   </data>
   <data name="MergeDialog_Instructions" xml:space="preserve">
     <value>請選擇2-5個GIF檔案進行合併（順序為由左至右）：</value>
@@ -609,6 +609,6 @@
   </data>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="lang_switch" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>C:\Users\Andyc\Downloads\lang_switch.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+    <value>..\Resources\lang_switch.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
 </root>


### PR DESCRIPTION
## Summary
- localize gifsicle notice label using resources
- provide Japanese and Traditional Chinese translations
- fix resource bitmap paths in localized resx files

## Testing
- `dotnet build`
- `dotnet test` *(fails: Error optimizing GIF: Input file does not exist, test run hung)*

------
https://chatgpt.com/codex/tasks/task_e_68b2ba96157c833099752b29e8ea1229