### PR TITLE
Localize five GIF merge status messages

### DIFF
--- a/GifProcessor.cs
+++ b/GifProcessor.cs
@@ -261,7 +261,7 @@ namespace GifProcessorApp
                 // Note: mergedFilePath is kept as the intermediate merged file
 
                 UpdateProgress(mainForm.pBarTaskStatus, 100, 100);
-                mainForm.lblStatus.Text = "Five GIF merge and split completed successfully!";
+                mainForm.lblStatus.Text = SteamGifCropper.Properties.Resources.MergeFiveGif_Success;
                 MessageBox.Show("Five GIF files have been merged and split into 5 parts successfully!",
                               SteamGifCropper.Properties.Resources.Title_Success, MessageBoxButtons.OK, MessageBoxIcon.Information);
 
@@ -274,7 +274,7 @@ namespace GifProcessorApp
             }
             catch (Exception ex)
             {
-                mainForm.lblStatus.Text = "Error occurred during processing.";
+                mainForm.lblStatus.Text = SteamGifCropper.Properties.Resources.MergeFiveGif_Error;
                 MessageBox.Show($"Error processing five GIF merge and split: {ex.Message}",
                               SteamGifCropper.Properties.Resources.Title_Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
             }

--- a/Properties/Resources.Designer.cs
+++ b/Properties/Resources.Designer.cs
@@ -383,7 +383,25 @@ namespace SteamGifCropper.Properties {
                 return ResourceManager.GetString("Message_GifMergeComplete", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to Five GIF merge and split completed successfully!.
+        /// </summary>
+        internal static string MergeFiveGif_Success {
+            get {
+                return ResourceManager.GetString("MergeFiveGif_Success", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Error occurred during processing..
+        /// </summary>
+        internal static string MergeFiveGif_Error {
+            get {
+                return ResourceManager.GetString("MergeFiveGif_Error", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to Please select 2-5 GIF files to merge (in order from left to right):.
         /// </summary>

--- a/Properties/Resources.ja.resx
+++ b/Properties/Resources.ja.resx
@@ -416,6 +416,12 @@
   <data name="Status_ErrorOccurred" xml:space="preserve">
     <value>エラーが発生しました</value>
   </data>
+  <data name="MergeFiveGif_Success" xml:space="preserve">
+    <value>5つのGIFの結合と分割が正常に完了しました！</value>
+  </data>
+  <data name="MergeFiveGif_Error" xml:space="preserve">
+    <value>処理中にエラーが発生しました。</value>
+  </data>
   <data name="Status_ProcessingPalette" xml:space="preserve">
     <value>パレット処理中...</value>
   </data>

--- a/Properties/Resources.resx
+++ b/Properties/Resources.resx
@@ -408,6 +408,12 @@
   <data name="Status_ErrorOccurred" xml:space="preserve">
     <value>Error occurred during processing.</value>
   </data>
+  <data name="MergeFiveGif_Success" xml:space="preserve">
+    <value>Five GIF merge and split completed successfully!</value>
+  </data>
+  <data name="MergeFiveGif_Error" xml:space="preserve">
+    <value>Error occurred during processing.</value>
+  </data>
   <data name="Status_ProcessingPalette" xml:space="preserve">
     <value>Processing with reduced palette...</value>
   </data>

--- a/Properties/Resources.zh-TW.resx
+++ b/Properties/Resources.zh-TW.resx
@@ -416,6 +416,12 @@
   <data name="Status_ErrorOccurred" xml:space="preserve">
     <value>發生錯誤</value>
   </data>
+  <data name="MergeFiveGif_Success" xml:space="preserve">
+    <value>五個GIF合併與分割已成功完成！</value>
+  </data>
+  <data name="MergeFiveGif_Error" xml:space="preserve">
+    <value>處理過程中發生錯誤。</value>
+  </data>
   <data name="Status_ProcessingPalette" xml:space="preserve">
     <value>處理調色盤中...</value>
   </data>


### PR DESCRIPTION
## Summary
- add MergeFiveGif_Success and MergeFiveGif_Error resources with translations
- use localized resources for five-GIF merge status updates

## Testing
- `dotnet test` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b2ef05ba788330ba2d8e6c7563e0b4