### PR TITLE
Localize merge dialog error messages

### DIFF
--- a/MergeGifsDialog.cs
+++ b/MergeGifsDialog.cs
@@ -425,18 +425,21 @@ namespace GifProcessorApp
             {
                 if (!File.Exists(filePath))
                 {
-                    MessageBox.Show($"File not found: {Path.GetFileName(filePath)}", 
-                                   SteamGifCropper.Properties.Resources.Title_Error, 
-                                   MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    MessageBox.Show(
+                        string.Format(SteamGifCropper.Properties.Resources.MergeDialog_FileNotFound,
+                                      Path.GetFileName(filePath)),
+                        SteamGifCropper.Properties.Resources.Title_Error,
+                        MessageBoxButtons.OK, MessageBoxIcon.Error);
                     return;
                 }
             }
 
             if (string.IsNullOrEmpty(txtOutputPath.Text))
             {
-                MessageBox.Show("Please specify an output GIF file.", 
-                               SteamGifCropper.Properties.Resources.Title_Warning, 
-                               MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                MessageBox.Show(
+                    SteamGifCropper.Properties.Resources.MergeDialog_RequireOutput,
+                    SteamGifCropper.Properties.Resources.Title_Warning,
+                    MessageBoxButtons.OK, MessageBoxIcon.Warning);
                 return;
             }
 
@@ -449,9 +452,10 @@ namespace GifProcessorApp
                 }
                 catch (Exception ex)
                 {
-                    MessageBox.Show($"Cannot create output directory:\n{ex.Message}", 
-                                   SteamGifCropper.Properties.Resources.Title_Error, 
-                                   MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    MessageBox.Show(
+                        $"{SteamGifCropper.Properties.Resources.MergeDialog_CannotCreateDir}\n{ex.Message}",
+                        SteamGifCropper.Properties.Resources.Title_Error,
+                        MessageBoxButtons.OK, MessageBoxIcon.Error);
                     return;
                 }
             }

--- a/Properties/Resources.Designer.cs
+++ b/Properties/Resources.Designer.cs
@@ -1175,7 +1175,34 @@ namespace SteamGifCropper.Properties {
                 return ResourceManager.GetString("MergeDialog_Title", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to File not found: {0}.
+        /// </summary>
+        internal static string MergeDialog_FileNotFound {
+            get {
+                return ResourceManager.GetString("MergeDialog_FileNotFound", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Please specify an output GIF file..
+        /// </summary>
+        internal static string MergeDialog_RequireOutput {
+            get {
+                return ResourceManager.GetString("MergeDialog_RequireOutput", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Cannot create output directory:.
+        /// </summary>
+        internal static string MergeDialog_CannotCreateDir {
+            get {
+                return ResourceManager.GetString("MergeDialog_CannotCreateDir", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to Input MP4 file:.
         /// </summary>

--- a/Properties/Resources.ja.resx
+++ b/Properties/Resources.ja.resx
@@ -518,6 +518,15 @@
   <data name="MergeDialog_Title" xml:space="preserve">
     <value>GIFファイルをマージ</value>
   </data>
+  <data name="MergeDialog_FileNotFound" xml:space="preserve">
+    <value>ファイルが見つかりません：{0}</value>
+  </data>
+  <data name="MergeDialog_RequireOutput" xml:space="preserve">
+    <value>出力GIFファイルを指定してください。</value>
+  </data>
+  <data name="MergeDialog_CannotCreateDir" xml:space="preserve">
+    <value>出力ディレクトリを作成できません：</value>
+  </data>
   <data name="Mp4Dialog_InputLabel" xml:space="preserve">
     <value>入力ファイル：</value>
   </data>

--- a/Properties/Resources.resx
+++ b/Properties/Resources.resx
@@ -510,6 +510,15 @@
   <data name="MergeDialog_Title" xml:space="preserve">
     <value>Merge GIF Files</value>
   </data>
+  <data name="MergeDialog_FileNotFound" xml:space="preserve">
+    <value>File not found: {0}</value>
+  </data>
+  <data name="MergeDialog_RequireOutput" xml:space="preserve">
+    <value>Please specify an output GIF file.</value>
+  </data>
+  <data name="MergeDialog_CannotCreateDir" xml:space="preserve">
+    <value>Cannot create output directory:</value>
+  </data>
   <data name="Mp4Dialog_InputLabel" xml:space="preserve">
     <value>Input MP4 file:</value>
   </data>

--- a/Properties/Resources.zh-TW.resx
+++ b/Properties/Resources.zh-TW.resx
@@ -518,6 +518,15 @@
   <data name="MergeDialog_Title" xml:space="preserve">
     <value>合併GIF檔案</value>
   </data>
+  <data name="MergeDialog_FileNotFound" xml:space="preserve">
+    <value>找不到檔案：{0}</value>
+  </data>
+  <data name="MergeDialog_RequireOutput" xml:space="preserve">
+    <value>請指定輸出的GIF檔案。</value>
+  </data>
+  <data name="MergeDialog_CannotCreateDir" xml:space="preserve">
+    <value>無法建立輸出目錄：</value>
+  </data>
   <data name="Mp4Dialog_InputLabel" xml:space="preserve">
     <value>輸入檔案：</value>
   </data>


### PR DESCRIPTION
## Summary
- replace hard-coded MessageBox strings in merge dialog with resource references
- add MergeDialog resource keys for missing file, required output path, and directory creation failures with ja/zh-TW translations
- expose new MergeDialog resource properties

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68b2f14918988330a0b2856648e655b8