### PR TITLE
Localize MP4→GIF status and dialog messages

### DIFF
--- a/Properties/Resources.Designer.cs
+++ b/Properties/Resources.Designer.cs
@@ -1463,6 +1463,159 @@ namespace SteamGifCropper.Properties {
                 return ResourceManager.GetString("Mp4Dialog_DirectoryError", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to FFmpeg is not installed or not available in the system PATH.\n\nFFmpeg Path: {0}\nVersion: {1}\n{2}\n\nTo install FFmpeg:\n1. Open Command Prompt or PowerShell as Administrator\n2. Run: winget install ffmpeg\n3. Restart this application\n\nFor more help, click the link in the MP4 to GIF dialog..
+        /// </summary>
+        internal static string Mp4ToGif_FFmpegRequiredMessage {
+            get {
+                return ResourceManager.GetString("Mp4ToGif_FFmpegRequiredMessage", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Short clip - CPU more efficient....
+        /// </summary>
+        internal static string Mp4ToGif_ShortClipCpu {
+            get {
+                return ResourceManager.GetString("Mp4ToGif_ShortClipCpu", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to GPU decode + CPU GIF encoding....
+        /// </summary>
+        internal static string Mp4ToGif_GpuCpuEncoding {
+            get {
+                return ResourceManager.GetString("Mp4ToGif_GpuCpuEncoding", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to GPU decode failed, using CPU....
+        /// </summary>
+        internal static string Mp4ToGif_GpuDecodeFailed {
+            get {
+                return ResourceManager.GetString("Mp4ToGif_GpuDecodeFailed", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to  (FFmpeg log: {0}).
+        /// </summary>
+        internal static string Mp4ToGif_FFmpegLog {
+            get {
+                return ResourceManager.GetString("Mp4ToGif_FFmpegLog", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to  FFmpeg output: {0}.
+        /// </summary>
+        internal static string Mp4ToGif_FFmpegOutput {
+            get {
+                return ResourceManager.GetString("Mp4ToGif_FFmpegOutput", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Converting MP4 to GIF with optimized CPU....
+        /// </summary>
+        internal static string Mp4ToGif_Converting {
+            get {
+                return ResourceManager.GetString("Mp4ToGif_Converting", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to MP4 to GIF conversion completed successfully!.
+        /// </summary>
+        internal static string Mp4ToGif_Success {
+            get {
+                return ResourceManager.GetString("Mp4ToGif_Success", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to MP4 to GIF conversion completed successfully!\nSaved as: {0}.
+        /// </summary>
+        internal static string Mp4ToGif_SuccessMessage {
+            get {
+                return ResourceManager.GetString("Mp4ToGif_SuccessMessage", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to FFmpeg executable not found. Please ensure FFmpeg is installed and available in your system PATH.\n\nInstallation: winget install ffmpeg.
+        /// </summary>
+        internal static string Mp4ToGif_Error_FFmpegNotFound {
+            get {
+                return ResourceManager.GetString("Mp4ToGif_Error_FFmpegNotFound", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to The input video file appears to be corrupted or incomplete.\n\nTry using a different video file or re-download the original..
+        /// </summary>
+        internal static string Mp4ToGif_Error_CorruptedInput {
+            get {
+                return ResourceManager.GetString("Mp4ToGif_Error_CorruptedInput", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to GPU acceleration failed. The conversion will automatically retry with CPU processing.\n\nThis is normal if your GPU drivers are outdated or CUDA is not properly installed..
+        /// </summary>
+        internal static string Mp4ToGif_Error_GPUFailed {
+            get {
+                return ResourceManager.GetString("Mp4ToGif_Error_GPUFailed", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Cannot access the output directory. Please check file permissions and ensure the directory is writable..
+        /// </summary>
+        internal static string Mp4ToGif_Error_PermissionDenied {
+            get {
+                return ResourceManager.GetString("Mp4ToGif_Error_PermissionDenied", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to An unexpected error occurred during MP4 to GIF conversion..
+        /// </summary>
+        internal static string Mp4ToGif_Error_Unexpected {
+            get {
+                return ResourceManager.GetString("Mp4ToGif_Error_Unexpected", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to \n\nDetailed FFmpeg output saved to: {0}.
+        /// </summary>
+        internal static string Mp4ToGif_Error_DetailsSaved {
+            get {
+                return ResourceManager.GetString("Mp4ToGif_Error_DetailsSaved", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to \n\nFFmpeg output (truncated):\n{0}.
+        /// </summary>
+        internal static string Mp4ToGif_Error_FFmpegOutputTruncated {
+            get {
+                return ResourceManager.GetString("Mp4ToGif_Error_FFmpegOutputTruncated", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to {0}\n\nInput file: "{1}"\nOutput file: "{2}"\nStart time: {3}\nDuration: {4}\n\nTechnical details: {5}.
+        /// </summary>
+        internal static string Mp4ToGif_ErrorMessageDetails {
+            get {
+                return ResourceManager.GetString("Mp4ToGif_ErrorMessageDetails", resourceCulture);
+            }
+        }
         
         /// <summary>
         ///   Looks up a localized string similar to MP4 Files (*.mp4)|*.mp4|All Video Files|*.mp4;*.avi;*.mkv;*.mov.

--- a/Properties/Resources.ja.resx
+++ b/Properties/Resources.ja.resx
@@ -625,6 +625,57 @@ Windows パッケージマネージャを使用した簡単なインストール
   <data name="Mp4Dialog_DirectoryError" xml:space="preserve">
     <value>ディレクトリエラー</value>
   </data>
+  <data name="Mp4ToGif_FFmpegRequiredMessage" xml:space="preserve">
+    <value>FFmpeg がインストールされていないか、システム PATH で利用できません。&#x0A;&#x0A;FFmpeg パス: {0}&#x0A;バージョン: {1}&#x0A;{2}&#x0A;&#x0A;FFmpeg をインストールするには:&#x0A;1. 管理者としてコマンド プロンプトまたは PowerShell を開く&#x0A;2. 実行: winget install ffmpeg&#x0A;3. 本アプリケーションを再起動&#x0A;&#x0A;詳細は MP4→GIF ダイアログのリンクを参照してください。</value>
+  </data>
+  <data name="Mp4ToGif_ShortClipCpu" xml:space="preserve">
+    <value>短いクリップ - CPU の方が効率的...</value>
+  </data>
+  <data name="Mp4ToGif_GpuCpuEncoding" xml:space="preserve">
+    <value>GPU デコード + CPU GIF エンコード...</value>
+  </data>
+  <data name="Mp4ToGif_GpuDecodeFailed" xml:space="preserve">
+    <value>GPU デコードに失敗、CPU を使用します...</value>
+  </data>
+  <data name="Mp4ToGif_FFmpegLog" xml:space="preserve">
+    <value> (FFmpeg ログ: {0})</value>
+  </data>
+  <data name="Mp4ToGif_FFmpegOutput" xml:space="preserve">
+    <value> FFmpeg 出力: {0}</value>
+  </data>
+  <data name="Mp4ToGif_Converting" xml:space="preserve">
+    <value>最適化された CPU で MP4 を GIF に変換中...</value>
+  </data>
+  <data name="Mp4ToGif_Success" xml:space="preserve">
+    <value>MP4 から GIF への変換が完了しました！</value>
+  </data>
+  <data name="Mp4ToGif_SuccessMessage" xml:space="preserve">
+    <value>MP4 から GIF への変換が完了しました！&#x0A;保存先: {0}</value>
+  </data>
+  <data name="Mp4ToGif_Error_FFmpegNotFound" xml:space="preserve">
+    <value>FFmpeg 実行ファイルが見つかりません。FFmpeg がインストールされ、システム PATH で利用可能であることを確認してください。&#x0A;&#x0A;インストール: winget install ffmpeg</value>
+  </data>
+  <data name="Mp4ToGif_Error_CorruptedInput" xml:space="preserve">
+    <value>入力動画ファイルが破損しているか不完全です。&#x0A;&#x0A;別の動画ファイルを使用するか、元のファイルを再ダウンロードしてください。</value>
+  </data>
+  <data name="Mp4ToGif_Error_GPUFailed" xml:space="preserve">
+    <value>GPU アクセラレーションに失敗しました。変換は自動的に CPU 処理で再試行します。&#x0A;&#x0A;GPU ドライバーが古いか CUDA が適切にインストールされていない場合は正常です。</value>
+  </data>
+  <data name="Mp4ToGif_Error_PermissionDenied" xml:space="preserve">
+    <value>出力ディレクトリにアクセスできません。ファイル権限を確認し、ディレクトリが書き込み可能であることを確認してください。</value>
+  </data>
+  <data name="Mp4ToGif_Error_Unexpected" xml:space="preserve">
+    <value>MP4 から GIF への変換中に予期しないエラーが発生しました。</value>
+  </data>
+  <data name="Mp4ToGif_Error_DetailsSaved" xml:space="preserve">
+    <value>&#x0A;&#x0A;FFmpeg の詳細出力が次に保存されました: {0}</value>
+  </data>
+  <data name="Mp4ToGif_Error_FFmpegOutputTruncated" xml:space="preserve">
+    <value>&#x0A;&#x0A;FFmpeg 出力（切り捨て）:&#x0A;{0}</value>
+  </data>
+  <data name="Mp4ToGif_ErrorMessageDetails" xml:space="preserve">
+    <value>{0}&#x0A;&#x0A;入力ファイル: "{1}"&#x0A;出力ファイル: "{2}"&#x0A;開始時間: {3}&#x0A;長さ: {4}&#x0A;&#x0A;技術的詳細: {5}</value>
+  </data>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="lang_switch" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\Resources\lang_switch.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>

--- a/Properties/Resources.resx
+++ b/Properties/Resources.resx
@@ -617,6 +617,57 @@ After installation, FFmpeg should be available in your system PATH.</value>
   <data name="Mp4Dialog_DirectoryError" xml:space="preserve">
     <value>Directory Error</value>
   </data>
+  <data name="Mp4ToGif_FFmpegRequiredMessage" xml:space="preserve">
+    <value>FFmpeg is not installed or not available in the system PATH.&#x0A;&#x0A;FFmpeg Path: {0}&#x0A;Version: {1}&#x0A;{2}&#x0A;&#x0A;To install FFmpeg:&#x0A;1. Open Command Prompt or PowerShell as Administrator&#x0A;2. Run: winget install ffmpeg&#x0A;3. Restart this application&#x0A;&#x0A;For more help, click the link in the MP4 to GIF dialog.</value>
+  </data>
+  <data name="Mp4ToGif_ShortClipCpu" xml:space="preserve">
+    <value>Short clip - CPU more efficient...</value>
+  </data>
+  <data name="Mp4ToGif_GpuCpuEncoding" xml:space="preserve">
+    <value>GPU decode + CPU GIF encoding...</value>
+  </data>
+  <data name="Mp4ToGif_GpuDecodeFailed" xml:space="preserve">
+    <value>GPU decode failed, using CPU...</value>
+  </data>
+  <data name="Mp4ToGif_FFmpegLog" xml:space="preserve">
+    <value> (FFmpeg log: {0})</value>
+  </data>
+  <data name="Mp4ToGif_FFmpegOutput" xml:space="preserve">
+    <value> FFmpeg output: {0}</value>
+  </data>
+  <data name="Mp4ToGif_Converting" xml:space="preserve">
+    <value>Converting MP4 to GIF with optimized CPU...</value>
+  </data>
+  <data name="Mp4ToGif_Success" xml:space="preserve">
+    <value>MP4 to GIF conversion completed successfully!</value>
+  </data>
+  <data name="Mp4ToGif_SuccessMessage" xml:space="preserve">
+    <value>MP4 to GIF conversion completed successfully!&#x0A;Saved as: {0}</value>
+  </data>
+  <data name="Mp4ToGif_Error_FFmpegNotFound" xml:space="preserve">
+    <value>FFmpeg executable not found. Please ensure FFmpeg is installed and available in your system PATH.&#x0A;&#x0A;Installation: winget install ffmpeg</value>
+  </data>
+  <data name="Mp4ToGif_Error_CorruptedInput" xml:space="preserve">
+    <value>The input video file appears to be corrupted or incomplete.&#x0A;&#x0A;Try using a different video file or re-download the original.</value>
+  </data>
+  <data name="Mp4ToGif_Error_GPUFailed" xml:space="preserve">
+    <value>GPU acceleration failed. The conversion will automatically retry with CPU processing.&#x0A;&#x0A;This is normal if your GPU drivers are outdated or CUDA is not properly installed.</value>
+  </data>
+  <data name="Mp4ToGif_Error_PermissionDenied" xml:space="preserve">
+    <value>Cannot access the output directory. Please check file permissions and ensure the directory is writable.</value>
+  </data>
+  <data name="Mp4ToGif_Error_Unexpected" xml:space="preserve">
+    <value>An unexpected error occurred during MP4 to GIF conversion.</value>
+  </data>
+  <data name="Mp4ToGif_Error_DetailsSaved" xml:space="preserve">
+    <value>&#x0A;&#x0A;Detailed FFmpeg output saved to: {0}</value>
+  </data>
+  <data name="Mp4ToGif_Error_FFmpegOutputTruncated" xml:space="preserve">
+    <value>&#x0A;&#x0A;FFmpeg output (truncated):&#x0A;{0}</value>
+  </data>
+  <data name="Mp4ToGif_ErrorMessageDetails" xml:space="preserve">
+    <value>{0}&#x0A;&#x0A;Input file: "{1}"&#x0A;Output file: "{2}"&#x0A;Start time: {3}&#x0A;Duration: {4}&#x0A;&#x0A;Technical details: {5}</value>
+  </data>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="lang_switch" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\Resources\lang_switch.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>

--- a/Properties/Resources.zh-TW.resx
+++ b/Properties/Resources.zh-TW.resx
@@ -625,6 +625,57 @@
   <data name="Mp4Dialog_DirectoryError" xml:space="preserve">
     <value>目錄錯誤</value>
   </data>
+  <data name="Mp4ToGif_FFmpegRequiredMessage" xml:space="preserve">
+    <value>FFmpeg 未安裝或未在系統 PATH 中提供。&#x0A;&#x0A;FFmpeg 路徑: {0}&#x0A;版本: {1}&#x0A;{2}&#x0A;&#x0A;安裝 FFmpeg：&#x0A;1. 以系統管理員開啟命令提示字元或 PowerShell&#x0A;2. 執行: winget install ffmpeg&#x0A;3. 重新啟動本應用程式&#x0A;&#x0A;更多說明請點擊 MP4 轉 GIF 對話框中的連結。</value>
+  </data>
+  <data name="Mp4ToGif_ShortClipCpu" xml:space="preserve">
+    <value>短片段－CPU 更有效率...</value>
+  </data>
+  <data name="Mp4ToGif_GpuCpuEncoding" xml:space="preserve">
+    <value>GPU 解碼 + CPU GIF 編碼...</value>
+  </data>
+  <data name="Mp4ToGif_GpuDecodeFailed" xml:space="preserve">
+    <value>GPU 解碼失敗，改用 CPU...</value>
+  </data>
+  <data name="Mp4ToGif_FFmpegLog" xml:space="preserve">
+    <value> (FFmpeg 日誌: {0})</value>
+  </data>
+  <data name="Mp4ToGif_FFmpegOutput" xml:space="preserve">
+    <value> FFmpeg 輸出: {0}</value>
+  </data>
+  <data name="Mp4ToGif_Converting" xml:space="preserve">
+    <value>以最佳化 CPU 將 MP4 轉為 GIF...</value>
+  </data>
+  <data name="Mp4ToGif_Success" xml:space="preserve">
+    <value>MP4 轉 GIF 成功完成！</value>
+  </data>
+  <data name="Mp4ToGif_SuccessMessage" xml:space="preserve">
+    <value>MP4 轉 GIF 成功完成！&#x0A;已儲存為: {0}</value>
+  </data>
+  <data name="Mp4ToGif_Error_FFmpegNotFound" xml:space="preserve">
+    <value>找不到 FFmpeg 執行檔。請確保已安裝 FFmpeg 並可於系統 PATH 存取。&#x0A;&#x0A;安裝指令: winget install ffmpeg</value>
+  </data>
+  <data name="Mp4ToGif_Error_CorruptedInput" xml:space="preserve">
+    <value>輸入的影片檔案似乎已損毀或不完整。&#x0A;&#x0A;請嘗試使用其他影片檔案或重新下載原始檔案。</value>
+  </data>
+  <data name="Mp4ToGif_Error_GPUFailed" xml:space="preserve">
+    <value>GPU 加速失敗。轉換將自動改用 CPU 處理。&#x0A;&#x0A;若 GPU 驅動程式過舊或未正確安裝 CUDA，這是正常情況。</value>
+  </data>
+  <data name="Mp4ToGif_Error_PermissionDenied" xml:space="preserve">
+    <value>無法存取輸出目錄。請檢查檔案權限並確保目錄可寫入。</value>
+  </data>
+  <data name="Mp4ToGif_Error_Unexpected" xml:space="preserve">
+    <value>MP4 轉 GIF 時發生未預期的錯誤。</value>
+  </data>
+  <data name="Mp4ToGif_Error_DetailsSaved" xml:space="preserve">
+    <value>&#x0A;&#x0A;詳細的 FFmpeg 輸出已儲存至: {0}</value>
+  </data>
+  <data name="Mp4ToGif_Error_FFmpegOutputTruncated" xml:space="preserve">
+    <value>&#x0A;&#x0A;FFmpeg 輸出 (部分)：&#x0A;{0}</value>
+  </data>
+  <data name="Mp4ToGif_ErrorMessageDetails" xml:space="preserve">
+    <value>{0}&#x0A;&#x0A;輸入檔案: "{1}"&#x0A;輸出檔案: "{2}"&#x0A;開始時間: {3}&#x0A;持續時間: {4}&#x0A;&#x0A;技術詳細資訊: {5}</value>
+  </data>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="lang_switch" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\Resources\lang_switch.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>


### PR DESCRIPTION
## Summary
- replace MP4→GIF status labels and dialogs with resource lookups
- add Mp4ToGif_* resource keys and provide Chinese and Japanese translations

## Testing
- `dotnet test` *(fails to locate WindowsDesktop targets but executes 21 tests successfully)*

------
https://chatgpt.com/codex/tasks/task_e_68b2f4496b3083309b65fc7e105766dc