### PR TITLE
Wire full cycle checkbox handler in constructor

### DIFF
--- a/ScrollStaticImageDialog.cs
+++ b/ScrollStaticImageDialog.cs
@@ -33,6 +33,7 @@ namespace GifProcessorApp
         public ScrollStaticImageDialog()
         {
             InitializeComponent();
+            chkFullCycle.CheckedChanged += ChkFullCycle_CheckedChanged;
             UpdateUIText();
             ApplyTheme();
         }
@@ -203,6 +204,8 @@ namespace GifProcessorApp
             }
         }
 
+        private void ChkFullCycle_CheckedChanged(object? sender, EventArgs e) => numDuration.Enabled = !chkFullCycle.Checked;
+
         private void BtnOK_Click(object? sender, EventArgs e)
         {
             if (string.IsNullOrWhiteSpace(txtInputPath.Text) || !File.Exists(txtInputPath.Text))
@@ -347,7 +350,6 @@ namespace GifProcessorApp
             chkFullCycle.Name = "chkFullCycle";
             chkFullCycle.Size = new System.Drawing.Size(130, 24);
             chkFullCycle.TabIndex = 12;
-            chkFullCycle.CheckedChanged += (s,e)=>{ numDuration.Enabled = !chkFullCycle.Checked; };
             //
             // btnOK
             //


### PR DESCRIPTION
## Summary
- Hook full-cycle checkbox event in constructor and remove inline lambda
- Disable duration input when full cycle is checked

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b39ccb0f5c83308b2dcc1bf9b9a397