### PR TITLE
Add duration-based scrolling for static images

### DIFF
--- a/GifProcessor.cs
+++ b/GifProcessor.cs
@@ -1774,6 +1774,18 @@ namespace GifProcessorApp
             int width = (int)baseImage.Width;
             int height = (int)baseImage.Height;
 
+            int distance = direction switch
+            {
+                ScrollDirection.Up or ScrollDirection.Down => height,
+                _ => width
+            };
+
+            int frames = Math.Max(1, durationSeconds * targetFramerate);
+            if (durationSeconds > 0)
+            {
+                stepPixels = Math.Max(1, (int)Math.Round((double)distance / frames));
+            }
+
             int dx = 0, dy = 0;
             switch (direction)
             {
@@ -1787,17 +1799,12 @@ namespace GifProcessorApp
                 case ScrollDirection.RightDown: dx = stepPixels; dy = stepPixels; break;
             }
 
-            int frames;
-            if (fullCycle)
+            if (durationSeconds <= 0 && fullCycle)
             {
                 int stepsX = dx != 0 ? (int)Math.Ceiling((double)width / Math.Abs(dx)) : 0;
                 int stepsY = dy != 0 ? (int)Math.Ceiling((double)height / Math.Abs(dy)) : 0;
                 frames = Math.Max(stepsX, stepsY);
                 if (frames <= 0) frames = 1;
-            }
-            else
-            {
-                frames = Math.Max(1, durationSeconds * targetFramerate);
             }
 
             uint delay = (uint)Math.Round(100.0 / targetFramerate);

--- a/Properties/Resources.ja.resx
+++ b/Properties/Resources.ja.resx
@@ -737,7 +737,7 @@ FFmpeg 出力（切り捨て）:
     <value>ピクセル/ステップ</value>
   </data>
   <data name="ScrollDialog_Duration" xml:space="preserve">
-    <value>秒数</value>
+    <value>スクロール1周の秒数</value>
   </data>
   <data name="ScrollDialog_FullCycle" xml:space="preserve">
     <value>一周させる</value>

--- a/Properties/Resources.resx
+++ b/Properties/Resources.resx
@@ -729,7 +729,7 @@ Technical details: {5}</value>
     <value>Pixels per step</value>
   </data>
   <data name="ScrollDialog_Duration" xml:space="preserve">
-    <value>Duration (sec)</value>
+    <value>Seconds per full scroll</value>
   </data>
   <data name="ScrollDialog_FullCycle" xml:space="preserve">
     <value>Scroll full cycle</value>

--- a/Properties/Resources.zh-TW.resx
+++ b/Properties/Resources.zh-TW.resx
@@ -737,7 +737,7 @@ FFmpeg 輸出 (部分)：
     <value>每步像素</value>
   </data>
   <data name="ScrollDialog_Duration" xml:space="preserve">
-    <value>持續秒數</value>
+    <value>每次完整捲動秒數</value>
   </data>
   <data name="ScrollDialog_FullCycle" xml:space="preserve">
     <value>整張圖捲動一次</value>

--- a/ScrollStaticImageDialog.cs
+++ b/ScrollStaticImageDialog.cs
@@ -11,7 +11,7 @@ namespace GifProcessorApp
         public string OutputFilePath { get; private set; } = string.Empty;
         public ScrollDirection Direction { get; private set; } = ScrollDirection.Right;
         public int StepPixels { get; private set; } = 1;
-        public int DurationSeconds { get; private set; } = 5;
+        public int DurationSeconds { get; private set; } = 0;
         public bool FullCycle { get; private set; }
 
         private TextBox txtInputPath = null!;
@@ -34,6 +34,8 @@ namespace GifProcessorApp
         {
             InitializeComponent();
             chkFullCycle.CheckedChanged += ChkFullCycle_CheckedChanged;
+            numDuration.ValueChanged += NumDuration_ValueChanged;
+            ChkFullCycle_CheckedChanged(null, EventArgs.Empty);
             UpdateUIText();
             ApplyTheme();
         }
@@ -204,7 +206,18 @@ namespace GifProcessorApp
             }
         }
 
-        private void ChkFullCycle_CheckedChanged(object? sender, EventArgs e) => numDuration.Enabled = !chkFullCycle.Checked;
+        private void ChkFullCycle_CheckedChanged(object? sender, EventArgs e)
+        {
+            numDuration.Enabled = chkFullCycle.Checked;
+            NumDuration_ValueChanged(sender, e);
+        }
+
+        private void NumDuration_ValueChanged(object? sender, EventArgs e)
+        {
+            bool useDuration = numDuration.Enabled && numDuration.Value > 0;
+            numStep.Visible = !useDuration;
+            lblStep.Visible = !useDuration;
+        }
 
         private void BtnOK_Click(object? sender, EventArgs e)
         {
@@ -221,8 +234,8 @@ namespace GifProcessorApp
             InputFilePath = txtInputPath.Text;
             OutputFilePath = txtOutputPath.Text;
             Direction = (ScrollDirection)cmbDirection.SelectedIndex;
-            StepPixels = (int)numStep.Value;
-            DurationSeconds = (int)numDuration.Value;
+            StepPixels = numStep.Visible ? (int)numStep.Value : 0;
+            DurationSeconds = numDuration.Enabled ? (int)numDuration.Value : 0;
             FullCycle = chkFullCycle.Checked;
             DialogResult = DialogResult.OK;
             Close();
@@ -255,7 +268,7 @@ namespace GifProcessorApp
             lblInput.Name = "lblInput";
             lblInput.Size = new System.Drawing.Size(120, 20);
             lblInput.TabIndex = 0;
-            lblInput.Text = "輸入圖像";
+            lblInput.Text = "J牊";
             // 
             // txtInputPath
             // 
@@ -281,7 +294,7 @@ namespace GifProcessorApp
             lblOutput.Name = "lblOutput";
             lblOutput.Size = new System.Drawing.Size(120, 20);
             lblOutput.TabIndex = 3;
-            lblOutput.Text = "輸出GIF";
+            lblOutput.Text = "XGIF";
             // 
             // txtOutputPath
             // 
@@ -323,7 +336,7 @@ namespace GifProcessorApp
             lblStep.Name = "lblStep";
             lblStep.Size = new System.Drawing.Size(120, 20);
             lblStep.TabIndex = 8;
-            lblStep.Text = "每步像素";
+            lblStep.Text = "CB";
             // 
             // numStep
             // 
@@ -340,17 +353,17 @@ namespace GifProcessorApp
             lblDuration.Name = "lblDuration";
             lblDuration.Size = new System.Drawing.Size(120, 20);
             lblDuration.TabIndex = 10;
-            lblDuration.Text = "持續秒數";
+            lblDuration.Text = "";
             // 
             // numDuration
             // 
             numDuration.Location = new System.Drawing.Point(140, 198);
             numDuration.Maximum = new decimal(new int[] { 600, 0, 0, 0 });
-            numDuration.Minimum = new decimal(new int[] { 1, 0, 0, 0 });
+            numDuration.Minimum = new decimal(new int[] { 0, 0, 0, 0 });
             numDuration.Name = "numDuration";
             numDuration.Size = new System.Drawing.Size(60, 23);
             numDuration.TabIndex = 11;
-            numDuration.Value = new decimal(new int[] { 5, 0, 0, 0 });
+            numDuration.Value = new decimal(new int[] { 0, 0, 0, 0 });
             // 
             // chkFullCycle
             // 
@@ -358,7 +371,7 @@ namespace GifProcessorApp
             chkFullCycle.Name = "chkFullCycle";
             chkFullCycle.Size = new System.Drawing.Size(130, 24);
             chkFullCycle.TabIndex = 12;
-            chkFullCycle.Text = "整張圖捲動一次";
+            chkFullCycle.Text = "i炱吨@";
             // 
             // btnOK
             // 
@@ -366,7 +379,7 @@ namespace GifProcessorApp
             btnOK.Name = "btnOK";
             btnOK.Size = new System.Drawing.Size(75, 25);
             btnOK.TabIndex = 13;
-            btnOK.Text = "取消";
+            btnOK.Text = "";
             btnOK.UseVisualStyleBackColor = true;
             btnOK.Click += BtnOK_Click;
             // 
@@ -405,7 +418,7 @@ namespace GifProcessorApp
             MinimizeBox = false;
             Name = "ScrollStaticImageDialog";
             StartPosition = FormStartPosition.CenterParent;
-            Text = "靜態圖捲動";
+            Text = "RA炱";
             ((System.ComponentModel.ISupportInitialize)numStep).EndInit();
             ((System.ComponentModel.ISupportInitialize)numDuration).EndInit();
             ResumeLayout(false);

--- a/SteamGifCropper.Tests/GifProcessor.Stub.cs
+++ b/SteamGifCropper.Tests/GifProcessor.Stub.cs
@@ -311,6 +311,19 @@ namespace GifProcessorApp
             using var baseImage = new MagickImage(inputFilePath);
             int width = (int)baseImage.Width;
             int height = (int)baseImage.Height;
+
+            int distance = direction switch
+            {
+                ScrollDirection.Up or ScrollDirection.Down => height,
+                _ => width
+            };
+
+            int frames = Math.Max(1, durationSeconds * targetFramerate);
+            if (durationSeconds > 0)
+            {
+                stepPixels = Math.Max(1, (int)Math.Round((double)distance / frames));
+            }
+
             int dx = 0, dy = 0;
             switch (direction)
             {
@@ -324,17 +337,12 @@ namespace GifProcessorApp
                 case ScrollDirection.RightDown: dx = stepPixels; dy = stepPixels; break;
             }
 
-            int frames;
-            if (fullCycle)
+            if (durationSeconds <= 0 && fullCycle)
             {
                 int stepsX = dx != 0 ? (int)Math.Ceiling((double)width / Math.Abs(dx)) : 0;
                 int stepsY = dy != 0 ? (int)Math.Ceiling((double)height / Math.Abs(dy)) : 0;
                 frames = Math.Max(stepsX, stepsY);
                 if (frames <= 0) frames = 1;
-            }
-            else
-            {
-                frames = Math.Max(1, durationSeconds * targetFramerate);
             }
 
             uint delay = (uint)Math.Round(100.0 / targetFramerate);

--- a/SteamGifCropper.Tests/ScrollStaticImageTests.cs
+++ b/SteamGifCropper.Tests/ScrollStaticImageTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using GifProcessorApp;
 using ImageMagick;
@@ -41,8 +42,8 @@ public class ScrollStaticImageTests
             ResourceLimits.Memory = 8UL * 1024UL * 1024UL;   // 8 MB to force disk fallback
             ResourceLimits.Disk = 128UL * 1024UL * 1024UL;  // 128 MB temporary disk space
 
-            GifProcessor.ScrollStaticImage(input, output, ScrollDirection.Right, 10, 1, false, 10);
-
+            GifProcessor.ScrollStaticImage(input, output, ScrollDirection.Right, 0, 1, true, 10);
+        
             using var collection = new MagickImageCollection(output);
             Assert.True(collection.Count > 1);
         }
@@ -52,5 +53,45 @@ public class ScrollStaticImageTests
             ResourceLimits.Disk = originalDisk;
             Directory.Delete(tempDir, true);
         }
+    }
+
+    [Theory]
+    [InlineData("Scroll_test_1.png", ScrollDirection.Right, 2, 10)]
+    [InlineData("Scroll_test_2.png", ScrollDirection.Down, 3, 10)]
+    public void ScrollStaticImage_DurationProducesExpectedScroll(string fileName, ScrollDirection direction, int duration, int framerate)
+    {
+        string input = Path.Combine("TestData", fileName);
+        string tempDir = Directory.CreateTempSubdirectory().FullName;
+        string output = Path.Combine(tempDir, "out.gif");
+
+        GifProcessor.ScrollStaticImage(input, output, direction, 0, duration, true, framerate);
+
+        using var baseImg = new MagickImage(input);
+        int distance = direction switch
+        {
+            ScrollDirection.Up or ScrollDirection.Down => (int)baseImg.Height,
+            _ => (int)baseImg.Width
+        };
+        int expectedFrames = duration * framerate;
+        int expectedStep = Math.Max(1, (int)Math.Round((double)distance / expectedFrames));
+
+        using var collection = new MagickImageCollection(output);
+        Assert.Equal(expectedFrames, collection.Count);
+
+        int offsetX = 0, offsetY = 0;
+        if (direction is ScrollDirection.Right or ScrollDirection.Left or ScrollDirection.LeftUp or ScrollDirection.LeftDown or ScrollDirection.RightUp or ScrollDirection.RightDown)
+            offsetX = expectedStep * (expectedFrames - 1) % (int)baseImg.Width;
+        if (direction is ScrollDirection.Up or ScrollDirection.Down or ScrollDirection.LeftUp or ScrollDirection.RightUp or ScrollDirection.LeftDown or ScrollDirection.RightDown)
+            offsetY = expectedStep * (expectedFrames - 1) % (int)baseImg.Height;
+
+        using var expectedLast = baseImg.Clone();
+        expectedLast.Roll(offsetX, offsetY);
+        double diff = collection[collection.Count - 1].Compare(expectedLast, ErrorMetric.RootMeanSquared);
+        Assert.True(diff < 0.02);
+
+        int totalScroll = expectedStep * expectedFrames;
+        Assert.InRange(totalScroll, distance - expectedStep, distance + expectedStep);
+
+        Directory.Delete(tempDir, true);
     }
 }


### PR DESCRIPTION
## Summary
- allow specifying seconds per full scroll in ScrollStaticImage dialog
- compute scroll step from duration in GifProcessor
- test scrolling by duration for large images

## Testing
- `dotnet test SteamGifCropper.Tests/SteamGifCropper.Tests.csproj -c Release`

------
https://chatgpt.com/codex/tasks/task_e_68b3b1edb0d88330b2b9906f78bc7439