### PR TITLE
Use collection writing for scroll animation

### DIFF
--- a/GifProcessor.cs
+++ b/GifProcessor.cs
@@ -1812,17 +1812,11 @@ namespace GifProcessorApp
             if (File.Exists(outputFilePath))
                 File.Delete(outputFilePath);
 
-            var defines = new GifWriteDefines
-            {
-                RepeatCount = 0,
-                WriteMode = GifWriteMode.Gif
-            };
-
-            using var stream = new FileStream(outputFilePath, FileMode.Create, FileAccess.Write);
+            using var collection = new MagickImageCollection();
 
             for (int i = 0; i < frames; i++)
             {
-                using var frame = baseImage.Clone();
+                var frame = baseImage.Clone();
                 int offsetX = dx * i;
                 int offsetY = dy * i;
                 if (width > 0)
@@ -1839,12 +1833,15 @@ namespace GifProcessorApp
                 frame.AnimationDelay = delay;
                 frame.GifDisposeMethod = GifDisposeMethod.Background;
 
-                using var collection = new MagickImageCollection();
                 collection.Add(frame);
-                collection.Write(stream, defines);
-
-                defines.WriteMode = GifWriteMode.Frame;
             }
+
+            var defines = new GifWriteDefines
+            {
+                RepeatCount = 0
+            };
+
+            collection.Write(outputFilePath, defines);
         }
 
         public static async Task ScrollStaticImage(GifToolMainForm mainForm)

--- a/SteamGifCropper.Tests/GifProcessor.Stub.cs
+++ b/SteamGifCropper.Tests/GifProcessor.Stub.cs
@@ -367,8 +367,13 @@ namespace GifProcessorApp
                 frame.GifDisposeMethod = GifDisposeMethod.Background;
                 collection.Add(frame);
             }
-            collection.Optimize();
-            collection.Write(outputFilePath);
+
+            var defines = new GifWriteDefines
+            {
+                RepeatCount = 0
+            };
+
+            collection.Write(outputFilePath, defines);
         }
     }
 }

--- a/SteamGifCropper.Tests/ScrollStaticImageTests.cs
+++ b/SteamGifCropper.Tests/ScrollStaticImageTests.cs
@@ -94,4 +94,22 @@ public class ScrollStaticImageTests
 
         Directory.Delete(tempDir, true);
     }
+
+    [Fact]
+    public void ScrollStaticImage_WithDuration_ProducesAnimatedGif()
+    {
+        string input = Path.Combine("TestData", "Scroll_test_1.png");
+        string tempDir = Directory.CreateTempSubdirectory().FullName;
+        string output = Path.Combine(tempDir, "out.gif");
+
+        GifProcessor.ScrollStaticImage(input, output, ScrollDirection.Right, 0, 2, true, 10);
+
+        using var collection = new MagickImageCollection(output);
+        Assert.True(collection.Count > 1);
+        Assert.Equal((ushort)0, collection[0].AnimationIterations);
+        double diff = collection[0].Compare(collection[1], ErrorMetric.RootMeanSquared);
+        Assert.True(diff > 0.0);
+
+        Directory.Delete(tempDir, true);
+    }
 }

--- a/SteamGifCropper.Tests/SteamGifCropper.Tests.csproj
+++ b/SteamGifCropper.Tests/SteamGifCropper.Tests.csproj
@@ -28,6 +28,7 @@
     <Compile Include="..\GifsicleWrapper.cs" Link="GifsicleWrapper.cs" />
     <Compile Include="..\RegistryProvider.cs" Link="RegistryProvider.cs" />
     <Compile Include="..\ScrollDirection.cs" Link="ScrollDirection.cs" />
+    <Compile Include="..\GifWriteDefines.cs" Link="GifWriteDefines.cs" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- Build all scroll frames in a single `MagickImageCollection` and output once with `GifWriteDefines` to retain animation metadata
- Add unit test ensuring `ScrollStaticImage` produces an animated GIF when a duration is provided

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b3bd2fea508330ad6dc44a1dc687e7