### PR TITLE
Localize processing frame progress message

### DIFF
--- a/GifProcessor.cs
+++ b/GifProcessor.cs
@@ -8,6 +8,7 @@ using System.Windows.Forms;
 using FFMpegCore;
 using FFMpegCore.Exceptions;
 using ImageMagick;
+using SteamGifCropper.Properties;
 
 namespace GifProcessorApp
 {
@@ -1909,7 +1910,7 @@ namespace GifProcessorApp
             {
                 mainForm.pBarTaskStatus.Maximum = frames;
                 mainForm.pBarTaskStatus.Value = 0;
-                mainForm.lblStatus.Text = $"Processing frame 0/{frames}";
+                mainForm.lblStatus.Text = string.Format(Resources.Status_ProcessingFrame, 0, frames);
             }));
 
             for (int i = 0; i < frames; i++)
@@ -1939,7 +1940,7 @@ namespace GifProcessorApp
                     mainForm.Invoke((Action)(() =>
                     {
                         mainForm.pBarTaskStatus.Value = current;
-                        mainForm.lblStatus.Text = $"Processing frame {current}/{frames}";
+                        mainForm.lblStatus.Text = string.Format(Resources.Status_ProcessingFrame, current, frames);
                     }));
                 }
             }

--- a/Properties/Resources.Designer.cs
+++ b/Properties/Resources.Designer.cs
@@ -779,6 +779,15 @@ namespace SteamGifCropper.Properties {
                 return ResourceManager.GetString("Status_ProcessingCount", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Processing frame {0}/{1}.
+        /// </summary>
+        internal static string Status_ProcessingFrame {
+            get {
+                return ResourceManager.GetString("Status_ProcessingFrame", resourceCulture);
+            }
+        }
         
         /// <summary>
         ///   Looks up a localized string similar to Processing with reduced palette....

--- a/Properties/Resources.ja.resx
+++ b/Properties/Resources.ja.resx
@@ -189,6 +189,9 @@
   <data name="Status_ProcessingCount" xml:space="preserve">
     <value>処理中... {0}/{1}</value>
   </data>
+  <data name="Status_ProcessingFrame" xml:space="preserve">
+    <value>フレーム{0}/{1}を処理中</value>
+  </data>
   <data name="Status_ResizingGif" xml:space="preserve">
     <value>GIF #{0}を{1}px幅にサイズ変更中...</value>
   </data>

--- a/Properties/Resources.resx
+++ b/Properties/Resources.resx
@@ -189,6 +189,9 @@
   <data name="Status_ProcessingCount" xml:space="preserve">
     <value>Processing... {0}/{1}</value>
   </data>
+  <data name="Status_ProcessingFrame" xml:space="preserve">
+    <value>Processing frame {0}/{1}</value>
+  </data>
   <data name="Status_ResizingGif" xml:space="preserve">
     <value>Resizing GIF #{0} to {1}px width...</value>
   </data>

--- a/Properties/Resources.zh-TW.resx
+++ b/Properties/Resources.zh-TW.resx
@@ -189,6 +189,9 @@
   <data name="Status_ProcessingCount" xml:space="preserve">
     <value>處理中... {0}/{1}</value>
   </data>
+  <data name="Status_ProcessingFrame" xml:space="preserve">
+    <value>處理影格 {0}/{1}</value>
+  </data>
   <data name="Status_ResizingGif" xml:space="preserve">
     <value>調整GIF #{0}至{1}px寬度...</value>
   </data>


### PR DESCRIPTION
## Summary
- use localized resource string for frame processing status updates
- add `Status_ProcessingFrame` entries to English, Japanese, and Traditional Chinese resource files
- expose new resource via regenerated `Resources.Designer.cs`

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets was not found)*
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b3ccaf828083308bd7b76044292d99