### PR TITLE
Update status labels during save and optimization

### DIFF
--- a/GifProcessor.cs
+++ b/GifProcessor.cs
@@ -1855,6 +1855,11 @@ namespace GifProcessorApp
                 RepeatCount = 0
             };
 
+            mainForm?.Invoke((Action)(() =>
+            {
+                mainForm.lblStatus.Text = Resources.Status_Saving;
+            }));
+
             collection.Write(outputFilePath, defines);
         }
 
@@ -1984,6 +1989,8 @@ namespace GifProcessorApp
                         OptimizeLevel = (int)mainForm.numUpDownOptimize.Value,
                         Dither = mainForm.DitherMethod
                     };
+                    mainForm.lblStatus.Text = SteamGifCropper.Properties.Resources.Status_GifsicleOptimizing;
+                    Application.DoEvents();
                     GifsicleWrapper.OptimizeGif(outputPath, outputPath, options);
                 }
 


### PR DESCRIPTION
## Summary
- show "Saving..." status while writing GIF frames in ScrollStaticImage
- update status to "gifsicle-ing..." before optimization in ScrollStaticImage wrapper
- confirm resource entries for these statuses in all locales

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b3cf1ba4008330b203ee66a7565fea