### PR TITLE
Disable form during static image scrolling

### DIFF
--- a/GifProcessor.cs
+++ b/GifProcessor.cs
@@ -1972,6 +1972,7 @@ namespace GifProcessorApp
             bool fullCycle = dialog.FullCycle;
             int targetFramerate = (int)mainForm.numUpDownFramerate.Value;
 
+            mainForm.Enabled = false;
             try
             {
                 mainForm.pBarTaskStatus.Visible = true;
@@ -2011,6 +2012,7 @@ namespace GifProcessorApp
             }
             finally
             {
+                mainForm.Enabled = true;
                 mainForm.pBarTaskStatus.Visible = false;
                 mainForm.lblStatus.Text = SteamGifCropper.Properties.Resources.Status_Ready;
             }


### PR DESCRIPTION
## Summary
- Disable main form while scrolling a static image to prevent user interaction during processing
- Restore form state in a `finally` block to ensure it is re-enabled on completion or error

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68b3d3f6bbd483308bde4725c36359d3