### PR TITLE
Avoid printing error on expected FileNotFoundException

### DIFF
--- a/GifsicleWrapper.cs
+++ b/GifsicleWrapper.cs
@@ -31,59 +31,50 @@ public class GifsicleWrapper
     {
         if (options == null) options = new GifsicleOptions();
 
-        try
+        // Validate paths
+        if (!File.Exists(inputPath))
+            throw new FileNotFoundException("Input file does not exist.", inputPath);
+
+        if (string.IsNullOrWhiteSpace(outputPath))
+            throw new ArgumentException("Output path cannot be null or empty.", nameof(outputPath));
+
+        // Construct command arguments
+        StringBuilder argsBuilder = new StringBuilder();
+        argsBuilder.Append($"--optimize={options.OptimizeLevel} ");
+        argsBuilder.Append($"--colors={options.Colors} ");
+        argsBuilder.Append($"--lossy={options.Lossy} ");
+
+        // Add dither options
+        switch (options.Dither)
         {
-            // Validate paths
-            if (!File.Exists(inputPath))
-                throw new FileNotFoundException("Input file does not exist.", inputPath);
-
-            if (string.IsNullOrWhiteSpace(outputPath))
-                throw new ArgumentException("Output path cannot be null or empty.");
-
-            // Construct command arguments
-            StringBuilder argsBuilder = new StringBuilder();
-            argsBuilder.Append($"--optimize={options.OptimizeLevel} ");
-            argsBuilder.Append($"--colors={options.Colors} ");
-            argsBuilder.Append($"--lossy={options.Lossy} ");
-
-            // Add dither options
-            switch (options.Dither)
-            {
-                case 1:
-                    argsBuilder.Append("--dither=ro64 ");
-                    break;
-                case 2:
-                    argsBuilder.Append("--dither=o8 ");
-                    break;
-                case 3:
-                    argsBuilder.Append("-f ");
-                    break;
-            }
-
-            argsBuilder.Append($"\"{inputPath}\" -o \"{outputPath}\"");
-
-            ProcessStartInfo startInfo = new ProcessStartInfo
-            {
-                FileName = "gifsicle", // ensure gifsicle is in system PATH
-                Arguments = argsBuilder.ToString(),
-                RedirectStandardOutput = true,
-                RedirectStandardError = true,
-                UseShellExecute = false,
-                CreateNoWindow = true
-            };
-
-            var (output, error) = ProcessRunner(startInfo);
-
-            if (!string.IsNullOrEmpty(error))
-            {
-                throw new Exception($"Gifsicle Error: {error}");
-            }
+            case 1:
+                argsBuilder.Append("--dither=ro64 ");
+                break;
+            case 2:
+                argsBuilder.Append("--dither=o8 ");
+                break;
+            case 3:
+                argsBuilder.Append("-f ");
+                break;
         }
-        catch (Exception ex)
+
+        argsBuilder.Append($"\"{inputPath}\" -o \"{outputPath}\"");
+
+        ProcessStartInfo startInfo = new ProcessStartInfo
         {
-            Console.WriteLine($"Error optimizing GIF: {ex.Message}");
-            Console.WriteLine(ex.StackTrace);
-            throw;
+            FileName = "gifsicle", // ensure gifsicle is in system PATH
+            Arguments = argsBuilder.ToString(),
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+
+        var (output, error) = ProcessRunner(startInfo);
+
+        if (!string.IsNullOrEmpty(error))
+        {
+            throw new Exception($"Gifsicle Error: {error}");
         }
     }
 }


### PR DESCRIPTION
## Summary
- Remove try/catch from `GifsicleWrapper.OptimizeGif`
- Directly validate paths and run gifsicle, throwing on stderr

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b3e57668e08330b34d2a1c208b2d86