### PR TITLE
Enable nullable annotations in ScrollStaticImageDialog

### DIFF
--- a/ScrollStaticImageDialog.cs
+++ b/ScrollStaticImageDialog.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.IO;
 using System.Windows.Forms;


### PR DESCRIPTION
## Summary
- enable nullable reference type annotations in ScrollStaticImageDialog

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*
- `dotnet test SteamGifCropper.Tests/SteamGifCropper.Tests.csproj -p:EnableWindowsTargeting=true`

------
https://chatgpt.com/codex/tasks/task_e_68b3e7dcbf3c83308c328395ee56c7e5