### PR TITLE
Add status update before saving scrolled image

### DIFF
--- a/GifProcessor.cs
+++ b/GifProcessor.cs
@@ -2004,7 +2004,25 @@ namespace GifProcessorApp
                 RepeatCount = 0
             };
 
+            if (mainForm != null)
+            {
+                mainForm.Invoke((Action)(() =>
+                {
+                    mainForm.lblStatus.Text = Resources.Status_Saving;
+                    Application.DoEvents();
+                }));
+            }
+
             collection.Write(outputFilePath, defines);
+
+            if (mainForm != null)
+            {
+                mainForm.Invoke((Action)(() =>
+                {
+                    mainForm.lblStatus.Text = Resources.Status_Done;
+                    Application.DoEvents();
+                }));
+            }
         }
 
         public static async Task ScrollStaticImage(GifToolMainForm mainForm)


### PR DESCRIPTION
## Summary
- show "Saving" and "Done" status messages around GIF write in `ScrollStaticImage`

## Testing
- `dotnet test` *(fails: command hung; build restored but tests did not complete)*

------
https://chatgpt.com/codex/tasks/task_e_68b3f1af904083308a8e9e52df8738e7