### PR TITLE
Add overlay GIF operation with localized UI labels

### DIFF
--- a/GTMainForm.Designer.cs
+++ b/GTMainForm.Designer.cs
@@ -466,8 +466,9 @@
             btnOverlayGIF.Name = "btnOverlayGIF";
             btnOverlayGIF.Size = new System.Drawing.Size(300, 26);
             btnOverlayGIF.TabIndex = 28;
-            btnOverlayGIF.Text = "Overlay GIF over GIF";
+            btnOverlayGIF.Text = SteamGifCropper.Properties.Resources.Button_OverlayGif;
             btnOverlayGIF.UseVisualStyleBackColor = true;
+            btnOverlayGIF.Click += btnOverlayGIF_Click;
             // 
             // GifToolMainForm
             // 

--- a/GTMainForm.cs
+++ b/GTMainForm.cs
@@ -177,6 +177,15 @@ namespace GifProcessorApp
             await ExecuteWithErrorHandling(async () => await GifProcessor.ScrollStaticImage(this), "static image scroll");
         }
 
+        private async void btnOverlayGIF_Click(object sender, EventArgs e)
+        {
+            await ExecuteWithErrorHandling(() =>
+            {
+                GifProcessor.OverlayGif(this);
+                return Task.CompletedTask;
+            }, "GIF overlay");
+        }
+
         private void label2_Click(object sender, EventArgs e)
         {
 
@@ -251,6 +260,7 @@ namespace GifProcessorApp
                 chk5GIFMergeFasterPaletteProcess.Text = SteamGifCropper.Properties.Resources.CheckBox_FasterPalette;
                 btnReverseGIF.Text = SteamGifCropper.Properties.Resources.Button_ReverseGif;
                 btnScrollStaticImage.Text = SteamGifCropper.Properties.Resources.Button_ScrollStaticImage;
+                btnOverlayGIF.Text = SteamGifCropper.Properties.Resources.Button_OverlayGif;
                 label1.Text = SteamGifCropper.Properties.Resources.Label_GifsicleNotice;
 
 

--- a/Properties/Resources.Designer.cs
+++ b/Properties/Resources.Designer.cs
@@ -1693,6 +1693,15 @@ namespace SteamGifCropper.Properties {
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to Overlay GIF over GIF.
+        /// </summary>
+        internal static string Button_OverlayGif {
+            get {
+                return ResourceManager.GetString("Button_OverlayGif", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Image Files (*.png;*.jpg;*.jpeg;*.bmp)|*.png;*.jpg;*.jpeg;*.bmp.
         /// </summary>
         internal static string FileDialog_ImageFilter {

--- a/Properties/Resources.ja.resx
+++ b/Properties/Resources.ja.resx
@@ -416,6 +416,9 @@
   <data name="Button_ScrollStaticImage" xml:space="preserve">
     <value>静止画像スクロール</value>
   </data>
+  <data name="Button_OverlayGif" xml:space="preserve">
+    <value>GIFを別のGIFに重ねる</value>
+  </data>
   <data name="Status_ValidatingProcessing" xml:space="preserve">
     <value>処理を検証中...</value>
   </data>

--- a/Properties/Resources.resx
+++ b/Properties/Resources.resx
@@ -408,6 +408,9 @@
   <data name="Button_ScrollStaticImage" xml:space="preserve">
     <value>Scroll static image</value>
   </data>
+  <data name="Button_OverlayGif" xml:space="preserve">
+    <value>Overlay GIF over GIF</value>
+  </data>
   <data name="Status_ValidatingProcessing" xml:space="preserve">
     <value>Validating and processing 5 GIF files...</value>
   </data>

--- a/Properties/Resources.zh-TW.resx
+++ b/Properties/Resources.zh-TW.resx
@@ -416,6 +416,9 @@
   <data name="Button_ScrollStaticImage" xml:space="preserve">
     <value>捲動靜態圖</value>
   </data>
+  <data name="Button_OverlayGif" xml:space="preserve">
+    <value>將GIF疊加在GIF上</value>
+  </data>
   <data name="Status_ValidatingProcessing" xml:space="preserve">
     <value>驗證處理中...</value>
   </data>


### PR DESCRIPTION
## Summary
- wire up Overlay GIF button click and text through resources
- add localized Button_OverlayGif strings and update UI refresh
- expose Button_OverlayGif in generated Resources class

## Testing
- `dotnet test` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b41b57bc7483308df5df4b2ae47d3e