### PR TITLE
Enable localization and status updates for overlay dialog

### DIFF
--- a/GifProcessor.cs
+++ b/GifProcessor.cs
@@ -2133,7 +2133,7 @@ namespace GifProcessorApp
 
             try
             {
-                mainForm.lblStatus.Text = SteamGifCropper.Properties.Resources.Status_Processing;
+                mainForm.lblStatus.Text = SteamGifCropper.Properties.Resources.Status_Loading;
                 mainForm.pBarTaskStatus.Minimum = 0;
                 mainForm.pBarTaskStatus.Maximum = 100;
                 mainForm.pBarTaskStatus.Value = 0;
@@ -2148,6 +2148,9 @@ namespace GifProcessorApp
 
                 baseCollection.Coalesce();
                 overlayCollection.Coalesce();
+
+                mainForm.lblStatus.Text = SteamGifCropper.Properties.Resources.Status_Overlaying;
+                Application.DoEvents();
 
                 if (resampleBase)
                 {
@@ -2276,7 +2279,7 @@ namespace GifProcessorApp
 
             mainForm.lblStatus.Text = SteamGifCropper.Properties.Resources.Status_Done;
             WindowsThemeManager.ShowThemeAwareMessageBox(mainForm,
-                "Overlay complete.",
+                SteamGifCropper.Properties.Resources.Message_OverlayComplete,
                 SteamGifCropper.Properties.Resources.Title_Success,
                 MessageBoxButtons.OK, MessageBoxIcon.Information);
         }

--- a/OverlayGifDialog.cs
+++ b/OverlayGifDialog.cs
@@ -35,7 +35,25 @@ namespace GifProcessorApp
         public OverlayGifDialog()
         {
             InitializeComponent();
+            UpdateUIText();
             WindowsThemeManager.ApplyThemeToControl(this, WindowsThemeManager.IsDarkModeEnabled());
+        }
+
+        /// <summary>
+        /// Refreshes user interface text based on the current culture.
+        /// </summary>
+        public void UpdateUIText()
+        {
+            lblBase.Text = _resources.GetString("lblBase.Text") ?? lblBase.Text;
+            btnBrowseBase.Text = _resources.GetString("btnBrowseBase.Text") ?? btnBrowseBase.Text;
+            lblOverlay.Text = _resources.GetString("lblOverlay.Text") ?? lblOverlay.Text;
+            btnBrowseOverlay.Text = _resources.GetString("btnBrowseOverlay.Text") ?? btnBrowseOverlay.Text;
+            chkResampleBase.Text = _resources.GetString("chkResampleBase.Text") ?? chkResampleBase.Text;
+            lblX.Text = _resources.GetString("lblX.Text") ?? lblX.Text;
+            lblY.Text = _resources.GetString("lblY.Text") ?? lblY.Text;
+            btnOK.Text = _resources.GetString("btnOK.Text") ?? btnOK.Text;
+            btnCancel.Text = _resources.GetString("btnCancel.Text") ?? btnCancel.Text;
+            Text = _resources.GetString("$this.Text") ?? Text;
         }
 
         private void BtnBrowseBase_Click(object sender, EventArgs e)

--- a/OverlayGifDialog.resx
+++ b/OverlayGifDialog.resx
@@ -117,4 +117,43 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="lblBase.Text" xml:space="preserve">
+    <value>Base GIF:</value>
+  </data>
+  <data name="btnBrowseBase.Text" xml:space="preserve">
+    <value>Browse...</value>
+  </data>
+  <data name="lblOverlay.Text" xml:space="preserve">
+    <value>Overlay GIF:</value>
+  </data>
+  <data name="btnBrowseOverlay.Text" xml:space="preserve">
+    <value>Browse...</value>
+  </data>
+  <data name="lblX.Text" xml:space="preserve">
+    <value>X:</value>
+  </data>
+  <data name="lblY.Text" xml:space="preserve">
+    <value>Y:</value>
+  </data>
+  <data name="btnOK.Text" xml:space="preserve">
+    <value>OK</value>
+  </data>
+  <data name="btnCancel.Text" xml:space="preserve">
+    <value>Cancel</value>
+  </data>
+  <data name="lblBaseInfo.Text" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="lblOverlayInfo.Text" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="chkResampleBase.Text" xml:space="preserve">
+    <value>Resample base GIF to overlay FPS</value>
+  </data>
+  <data name="GifInfoFormat" xml:space="preserve">
+    <value>{0}×{1}, {2} fps</value>
+  </data>
+  <data name="$this.Text" xml:space="preserve">
+    <value>Overlay GIF</value>
+  </data>
 </root>

--- a/Properties/Resources.Designer.cs
+++ b/Properties/Resources.Designer.cs
@@ -455,6 +455,15 @@ namespace SteamGifCropper.Properties {
                 return ResourceManager.GetString("Message_Mp4ConversionComplete", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Overlay complete..
+        /// </summary>
+        internal static string Message_OverlayComplete {
+            get {
+                return ResourceManager.GetString("Message_OverlayComplete", resourceCulture);
+            }
+        }
         
         /// <summary>
         ///   Looks up a localized string similar to GIF processing with reduced palette completed successfully!.
@@ -678,6 +687,15 @@ namespace SteamGifCropper.Properties {
         internal static string Status_Loading {
             get {
                 return ResourceManager.GetString("Status_Loading", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Overlaying....
+        /// </summary>
+        internal static string Status_Overlaying {
+            get {
+                return ResourceManager.GetString("Status_Overlaying", resourceCulture);
             }
         }
 

--- a/Properties/Resources.ja.resx
+++ b/Properties/Resources.ja.resx
@@ -174,6 +174,9 @@
   <data name="Status_Loading" xml:space="preserve">
     <value>読み込み中...</value>
   </data>
+  <data name="Status_Overlaying" xml:space="preserve">
+    <value>オーバーレイ中...</value>
+  </data>
   <data name="Status_ResizingFrames" xml:space="preserve">
     <value>フレームサイズ変更中...</value>
   </data>
@@ -283,6 +286,9 @@
   <data name="Message_Mp4ConversionComplete" xml:space="preserve">
     <value>MP4からGIFへの変換が完了しました！
 出力ファイル：{0}</value>
+  </data>
+  <data name="Message_OverlayComplete" xml:space="preserve">
+    <value>オーバーレイが完了しました。</value>
   </data>
   <data name="Message_ProcessedFiles" xml:space="preserve">
     <value>{1} 個のGIFファイルのうち {0} 個が正常に処理されました！</value>

--- a/Properties/Resources.resx
+++ b/Properties/Resources.resx
@@ -174,6 +174,9 @@
   <data name="Status_Loading" xml:space="preserve">
     <value>Loading...</value>
   </data>
+  <data name="Status_Overlaying" xml:space="preserve">
+    <value>Overlaying...</value>
+  </data>
   <data name="Status_ResizingFrames" xml:space="preserve">
     <value>Resizing frames...</value>
   </data>
@@ -281,6 +284,9 @@
   </data>
   <data name="Message_Mp4ConversionComplete" xml:space="preserve">
     <value>MP4 to GIF conversion completed successfully!\nSaved as: {0}</value>
+  </data>
+  <data name="Message_OverlayComplete" xml:space="preserve">
+    <value>Overlay complete.</value>
   </data>
   <data name="Message_ProcessedFiles" xml:space="preserve">
     <value>{0} of {1} GIF files processed successfully!</value>

--- a/Properties/Resources.zh-TW.resx
+++ b/Properties/Resources.zh-TW.resx
@@ -174,6 +174,9 @@
   <data name="Status_Loading" xml:space="preserve">
     <value>載入中...</value>
   </data>
+  <data name="Status_Overlaying" xml:space="preserve">
+    <value>正在覆蓋...</value>
+  </data>
   <data name="Status_ResizingFrames" xml:space="preserve">
     <value>調整影格大小中...</value>
   </data>
@@ -283,6 +286,9 @@
   <data name="Message_Mp4ConversionComplete" xml:space="preserve">
     <value>MP4轉GIF完成！
 輸出檔案：{0}</value>
+  </data>
+  <data name="Message_OverlayComplete" xml:space="preserve">
+    <value>覆蓋完成。</value>
   </data>
   <data name="Message_ProcessedFiles" xml:space="preserve">
     <value>{1} 個 GIF 檔案中的 {0} 個已成功處理！</value>


### PR DESCRIPTION
## Summary
- Localize overlay dialog via resource-based text and default English strings
- Add overlay processing status and localized completion message
- Translate new resources for Japanese and Traditional Chinese

## Testing
- `dotnet test` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b446929f348330bac44b2f32a8fe3c