### PR TITLE
Add localization resources for ResizeNfpsGif dialog

### DIFF
--- a/GTMainForm.cs
+++ b/GTMainForm.cs
@@ -261,6 +261,7 @@ namespace GifProcessorApp
                 btnReverseGIF.Text = SteamGifCropper.Properties.Resources.Button_ReverseGif;
                 btnScrollStaticImage.Text = SteamGifCropper.Properties.Resources.Button_ScrollStaticImage;
                 btnOverlayGIF.Text = SteamGifCropper.Properties.Resources.Button_OverlayGif;
+                btnResizeNfpsGIF.Text = SteamGifCropper.Properties.Resources.Button_ResizeNfpsGif;
                 label1.Text = SteamGifCropper.Properties.Resources.Label_GifsicleNotice;
 
 

--- a/Program.cs
+++ b/Program.cs
@@ -165,10 +165,13 @@ namespace GifProcessorApp
                 // Set both current culture and UI culture
                 Thread.CurrentThread.CurrentCulture = targetCulture;
                 Thread.CurrentThread.CurrentUICulture = targetCulture;
-                
+
                 // Set default culture for new threads
                 CultureInfo.DefaultThreadCurrentCulture = targetCulture;
                 CultureInfo.DefaultThreadCurrentUICulture = targetCulture;
+
+                // Ensure resources use the selected culture
+                SteamGifCropper.Properties.Resources.Culture = targetCulture;
 
                 // Debug logging
                 System.Diagnostics.Debug.WriteLine($"Localization initialized: {targetCulture.Name} ({targetCulture.DisplayName})");

--- a/Properties/Resources.Designer.cs
+++ b/Properties/Resources.Designer.cs
@@ -203,6 +203,15 @@ namespace SteamGifCropper.Properties {
                 return ResourceManager.GetString("Error_ResizeFailed", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Please select a GIF file.
+        /// </summary>
+        internal static string Error_SelectGif {
+            get {
+                return ResourceManager.GetString("Error_SelectGif", resourceCulture);
+            }
+        }
         
         /// <summary>
         ///   Looks up a localized string similar to Application startup failed: {0}\n\nStack trace:\n{1}.
@@ -1716,6 +1725,15 @@ namespace SteamGifCropper.Properties {
         internal static string Button_OverlayGif {
             get {
                 return ResourceManager.GetString("Button_OverlayGif", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Resize / re-FPS GIF.
+        /// </summary>
+        internal static string Button_ResizeNfpsGif {
+            get {
+                return ResourceManager.GetString("Button_ResizeNfpsGif", resourceCulture);
             }
         }
 

--- a/Properties/Resources.ja.resx
+++ b/Properties/Resources.ja.resx
@@ -314,6 +314,9 @@
   <data name="Error_ResizeFailed" xml:space="preserve">
     <value>サイズ変更に失敗しました：{0}</value>
   </data>
+  <data name="Error_SelectGif" xml:space="preserve">
+    <value>GIF ファイルを選択してください。</value>
+  </data>
   <data name="Error_StartupFailed" xml:space="preserve">
     <value>起動に失敗しました：{0}\n\nスタックトレース：{1}</value>
   </data>
@@ -424,6 +427,9 @@
   </data>
   <data name="Button_OverlayGif" xml:space="preserve">
     <value>GIFを別のGIFに重ねる</value>
+  </data>
+  <data name="Button_ResizeNfpsGif" xml:space="preserve">
+    <value>GIF のサイズ/FPS を変更</value>
   </data>
   <data name="Status_ValidatingProcessing" xml:space="preserve">
     <value>処理を検証中...</value>

--- a/Properties/Resources.resx
+++ b/Properties/Resources.resx
@@ -312,6 +312,9 @@
   <data name="Error_ResizeFailed" xml:space="preserve">
     <value>Resize operation failed: {0}</value>
   </data>
+  <data name="Error_SelectGif" xml:space="preserve">
+    <value>Please select a GIF file.</value>
+  </data>
   <data name="Error_StartupFailed" xml:space="preserve">
     <value>Application startup failed: {0}\n\nStack trace:\n{1}</value>
   </data>
@@ -416,6 +419,9 @@
   </data>
   <data name="Button_OverlayGif" xml:space="preserve">
     <value>Overlay GIF over GIF</value>
+  </data>
+  <data name="Button_ResizeNfpsGif" xml:space="preserve">
+    <value>Resize / re-FPS GIF</value>
   </data>
   <data name="Status_ValidatingProcessing" xml:space="preserve">
     <value>Validating and processing 5 GIF files...</value>

--- a/Properties/Resources.zh-TW.resx
+++ b/Properties/Resources.zh-TW.resx
@@ -314,6 +314,9 @@
   <data name="Error_ResizeFailed" xml:space="preserve">
     <value>調整大小失敗：{0}</value>
   </data>
+  <data name="Error_SelectGif" xml:space="preserve">
+    <value>請選擇 GIF 檔案。</value>
+  </data>
   <data name="Error_StartupFailed" xml:space="preserve">
     <value>啟動失敗：{0}\n\n堆疊追蹤：{1}</value>
   </data>
@@ -424,6 +427,9 @@
   </data>
   <data name="Button_OverlayGif" xml:space="preserve">
     <value>將GIF疊加在GIF上</value>
+  </data>
+  <data name="Button_ResizeNfpsGif" xml:space="preserve">
+    <value>調整或重設 GIF 大小／FPS</value>
   </data>
   <data name="Status_ValidatingProcessing" xml:space="preserve">
     <value>驗證處理中...</value>

--- a/ResizeNfpsGifDialog.cs
+++ b/ResizeNfpsGifDialog.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Windows.Forms;
+using System.Resources;
 using FFMpegCore;
 using FFMpegCore.Pipes;
 using ImageMagick;
@@ -16,11 +17,30 @@ namespace GifProcessorApp
 
         private double _aspectRatio = 1.0;
         private bool _suppressEvents;
+        private readonly ResourceManager _resources = new("SteamGifCropper.Resources.ResizeNfpsGifDialog", typeof(ResizeNfpsGifDialog).Assembly);
 
         public ResizeNfpsGifDialog()
         {
             InitializeComponent();
+            UpdateUIText();
             WindowsThemeManager.ApplyThemeToControl(this, WindowsThemeManager.IsDarkModeEnabled());
+        }
+
+        /// <summary>
+        /// Refreshes user interface text based on the current culture.
+        /// </summary>
+        public void UpdateUIText()
+        {
+            lblGif.Text = _resources.GetString("lblGif.Text") ?? lblGif.Text;
+            btnBrowse.Text = _resources.GetString("btnBrowse.Text") ?? btnBrowse.Text;
+            lblOriginalLabel.Text = _resources.GetString("lblOriginalLabel.Text") ?? lblOriginalLabel.Text;
+            lblWidth.Text = _resources.GetString("lblWidth.Text") ?? lblWidth.Text;
+            lblHeight.Text = _resources.GetString("lblHeight.Text") ?? lblHeight.Text;
+            lblFps.Text = _resources.GetString("lblFps.Text") ?? lblFps.Text;
+            chkLockRatio.Text = _resources.GetString("chkLockRatio.Text") ?? chkLockRatio.Text;
+            btnOk.Text = _resources.GetString("btnOk.Text") ?? btnOk.Text;
+            btnCancel.Text = _resources.GetString("btnCancel.Text") ?? btnCancel.Text;
+            Text = _resources.GetString("$this.Text") ?? Text;
         }
 
         private void BtnBrowse_Click(object sender, EventArgs e)
@@ -96,7 +116,12 @@ namespace GifProcessorApp
         {
             if (!File.Exists(InputGifPath))
             {
-                WindowsThemeManager.ShowThemeAwareMessageBox(this, "Please select a GIF file.", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                WindowsThemeManager.ShowThemeAwareMessageBox(
+                    this,
+                    SteamGifCropper.Properties.Resources.Error_SelectGif,
+                    SteamGifCropper.Properties.Resources.Title_Error,
+                    MessageBoxButtons.OK,
+                    MessageBoxIcon.Error);
                 return;
             }
 
@@ -110,11 +135,21 @@ namespace GifProcessorApp
                 try
                 {
                     ConvertWithFfmpeg(InputGifPath, saveDialog.FileName, NewWidth, NewHeight, NewFps);
-                    WindowsThemeManager.ShowThemeAwareMessageBox(this, SteamGifCropper.Properties.Resources.Message_ResizeComplete, "Success", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                    WindowsThemeManager.ShowThemeAwareMessageBox(
+                        this,
+                        SteamGifCropper.Properties.Resources.Message_ResizeComplete,
+                        SteamGifCropper.Properties.Resources.Title_Success,
+                        MessageBoxButtons.OK,
+                        MessageBoxIcon.Information);
                 }
                 catch (Exception ex)
                 {
-                    WindowsThemeManager.ShowThemeAwareMessageBox(this, string.Format(SteamGifCropper.Properties.Resources.Error_ResizeFailed, ex.Message), "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    WindowsThemeManager.ShowThemeAwareMessageBox(
+                        this,
+                        string.Format(SteamGifCropper.Properties.Resources.Error_ResizeFailed, ex.Message),
+                        SteamGifCropper.Properties.Resources.Title_Error,
+                        MessageBoxButtons.OK,
+                        MessageBoxIcon.Error);
                 }
             }
         }

--- a/Resources/ResizeNfpsGifDialog.ja.resx
+++ b/Resources/ResizeNfpsGifDialog.ja.resx
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="lblGif.Text" xml:space="preserve">
+    <value>GIF:</value>
+  </data>
+  <data name="btnBrowse.Text" xml:space="preserve">
+    <value>参照</value>
+  </data>
+  <data name="lblOriginalLabel.Text" xml:space="preserve">
+    <value>オリジナル:</value>
+  </data>
+  <data name="lblWidth.Text" xml:space="preserve">
+    <value>幅:</value>
+  </data>
+  <data name="lblHeight.Text" xml:space="preserve">
+    <value>高さ:</value>
+  </data>
+  <data name="lblFps.Text" xml:space="preserve">
+    <value>FPS:</value>
+  </data>
+  <data name="chkLockRatio.Text" xml:space="preserve">
+    <value>アスペクト比を固定</value>
+  </data>
+  <data name="btnOk.Text" xml:space="preserve">
+    <value>OK</value>
+  </data>
+  <data name="btnCancel.Text" xml:space="preserve">
+    <value>キャンセル</value>
+  </data>
+  <data name="$this.Text" xml:space="preserve">
+    <value>GIF サイズ/FPS 変更</value>
+  </data>
+</root>

--- a/Resources/ResizeNfpsGifDialog.resx
+++ b/Resources/ResizeNfpsGifDialog.resx
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="lblGif.Text" xml:space="preserve">
+    <value>GIF:</value>
+  </data>
+  <data name="btnBrowse.Text" xml:space="preserve">
+    <value>Browse</value>
+  </data>
+  <data name="lblOriginalLabel.Text" xml:space="preserve">
+    <value>Original:</value>
+  </data>
+  <data name="lblWidth.Text" xml:space="preserve">
+    <value>Width:</value>
+  </data>
+  <data name="lblHeight.Text" xml:space="preserve">
+    <value>Height:</value>
+  </data>
+  <data name="lblFps.Text" xml:space="preserve">
+    <value>FPS:</value>
+  </data>
+  <data name="chkLockRatio.Text" xml:space="preserve">
+    <value>Lock aspect ratio</value>
+  </data>
+  <data name="btnOk.Text" xml:space="preserve">
+    <value>OK</value>
+  </data>
+  <data name="btnCancel.Text" xml:space="preserve">
+    <value>Cancel</value>
+  </data>
+  <data name="$this.Text" xml:space="preserve">
+    <value>Resize GIF</value>
+  </data>
+</root>

--- a/Resources/ResizeNfpsGifDialog.zh-TW.resx
+++ b/Resources/ResizeNfpsGifDialog.zh-TW.resx
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="lblGif.Text" xml:space="preserve">
+    <value>GIF：</value>
+  </data>
+  <data name="btnBrowse.Text" xml:space="preserve">
+    <value>瀏覽</value>
+  </data>
+  <data name="lblOriginalLabel.Text" xml:space="preserve">
+    <value>原始：</value>
+  </data>
+  <data name="lblWidth.Text" xml:space="preserve">
+    <value>寬度：</value>
+  </data>
+  <data name="lblHeight.Text" xml:space="preserve">
+    <value>高度：</value>
+  </data>
+  <data name="lblFps.Text" xml:space="preserve">
+    <value>FPS：</value>
+  </data>
+  <data name="chkLockRatio.Text" xml:space="preserve">
+    <value>鎖定長寬比</value>
+  </data>
+  <data name="btnOk.Text" xml:space="preserve">
+    <value>確定</value>
+  </data>
+  <data name="btnCancel.Text" xml:space="preserve">
+    <value>取消</value>
+  </data>
+  <data name="$this.Text" xml:space="preserve">
+    <value>調整 GIF 大小與 FPS</value>
+  </data>
+</root>

--- a/SteamGifCropper.csproj
+++ b/SteamGifCropper.csproj
@@ -82,5 +82,16 @@
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>
     </None>
   </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Update="Resources\ResizeNfpsGifDialog.resx">
+      <Generator></Generator>
+    </EmbeddedResource>
+    <EmbeddedResource Update="Resources\ResizeNfpsGifDialog.zh-TW.resx">
+      <Generator></Generator>
+    </EmbeddedResource>
+    <EmbeddedResource Update="Resources\ResizeNfpsGifDialog.ja.resx">
+      <Generator></Generator>
+    </EmbeddedResource>
+  </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- add resource files and translations for ResizeNfpsGifDialog
- load localized strings in ResizeNfpsGifDialog and main form button
- ensure resources use selected culture during initialization

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-8.0` *(fails: Unable to locate package dotnet-sdk-8.0)*

------
https://chatgpt.com/codex/tasks/task_e_68b44e29a9c08330a4871108a991f8b5