### PR TITLE
Ensure ResizeNfpsGifDialog honors Windows theme settings

### DIFF
--- a/GTMainForm.cs
+++ b/GTMainForm.cs
@@ -65,6 +65,7 @@ namespace GifProcessorApp
             {
                 WindowsThemeManager.ApplyThemeToControl(this, _isDarkMode);
                 WindowsThemeManager.ApplyThemeToControl(conMenuLangSwitch, _isDarkMode);
+                WindowsThemeManager.ApplyThemeToControl(btnResizeNfpsGIF, _isDarkMode);
                 this.Refresh();
             }
             catch (Exception ex)

--- a/ResizeNfpsGifDialog.cs
+++ b/ResizeNfpsGifDialog.cs
@@ -23,7 +23,22 @@ namespace GifProcessorApp
         {
             InitializeComponent();
             UpdateUIText();
+        }
+
+        protected override void OnLoad(EventArgs e)
+        {
+            base.OnLoad(e);
             WindowsThemeManager.ApplyThemeToControl(this, WindowsThemeManager.IsDarkModeEnabled());
+        }
+
+        protected override void SetVisibleCore(bool value)
+        {
+            base.SetVisibleCore(value);
+
+            if (value && IsHandleCreated)
+            {
+                WindowsThemeManager.SetDarkModeForWindow(this.Handle, WindowsThemeManager.IsDarkModeEnabled());
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- Apply Windows theme on load in ResizeNfpsGifDialog and ensure dark mode is set when the window becomes visible
- Include btnResizeNfpsGIF in GTMainForm theme updates

## Testing
- `dotnet test` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b4526713a8833084cd537d2eb1e1cf