### PR TITLE
Add Resize/Re-FPS GIF button with dynamic FFmpeg label

### DIFF
--- a/GTMainForm.Designer.cs
+++ b/GTMainForm.Designer.cs
@@ -477,8 +477,9 @@
             btnResizeNfpsGIF.Name = "btnResizeNfpsGIF";
             btnResizeNfpsGIF.Size = new System.Drawing.Size(300, 26);
             btnResizeNfpsGIF.TabIndex = 29;
-            btnResizeNfpsGIF.Text = "Resize / re-FPS GIF";
+            btnResizeNfpsGIF.Text = SteamGifCropper.Properties.Resources.Button_ResizeNfpsGif;
             btnResizeNfpsGIF.UseVisualStyleBackColor = true;
+            btnResizeNfpsGIF.Click += btnResizeNfpsGIF_Click;
             // 
             // GifToolMainForm
             // 


### PR DESCRIPTION
## Summary
- Add btnResizeNfpsGIF click handler to open resize/re-FPS dialog.
- Dynamically prefix resize button text with `FFMPEG:` when ffmpeg is available.
- Wire up designer for new button layout and event.

## Testing
- `dotnet test` *(fails: Assert.Equal() failure in MergeGifTests)*

------
https://chatgpt.com/codex/tasks/task_e_68b455f8b0e48330bd180b0171cf3551