### PR TITLE
Parameterize ImageMagick resource limits

### DIFF
--- a/SteamGifCropper.Tests/GifProcessor.Stub.cs
+++ b/SteamGifCropper.Tests/GifProcessor.Stub.cs
@@ -190,8 +190,13 @@ namespace GifProcessorApp
             await Task.CompletedTask;
         }
 
-        private static void MergeGifsHorizontally(MagickImageCollection[] collections, string outputPath, GifToolMainForm mainForm, bool useFastPalette = false)
+        private static void MergeGifsHorizontally(MagickImageCollection[] collections, string outputPath, GifToolMainForm mainForm,
+            bool useFastPalette, ulong memoryLimitBytes, ulong diskLimitBytes)
         {
+            // Apply resource limits in bytes to mirror production behavior
+            ResourceLimits.Memory = memoryLimitBytes;
+            ResourceLimits.Disk = diskLimitBytes;
+
             int maxHeight = collections.Max(c => (int)c[0].Height);
             using var palette = BuildSharedPalette(collections, useFastPalette);
             var mapSettings = new QuantizeSettings

--- a/SteamGifCropper.Tests/MergeGifTests.cs
+++ b/SteamGifCropper.Tests/MergeGifTests.cs
@@ -151,7 +151,7 @@ public class MergeGifTests
             var form = new GifToolMainForm();
             var method = typeof(GifProcessor).GetMethod("MergeGifsHorizontally", BindingFlags.NonPublic | BindingFlags.Static)!;
             string mergedPath = Path.Combine(tempDir, "merged.gif");
-            method.Invoke(null, new object?[] { collections, mergedPath, form, false });
+            method.Invoke(null, new object?[] { collections, mergedPath, form, false, ResourceLimits.Memory, ResourceLimits.Disk });
             using var merged = new MagickImageCollection(mergedPath);
             Assert.Equal(766U, merged[0].Width);
 
@@ -198,7 +198,7 @@ public class MergeGifTests
             var form = new GifToolMainForm();
             var method = typeof(GifProcessor).GetMethod("MergeGifsHorizontally", BindingFlags.NonPublic | BindingFlags.Static)!;
             string outputPath = Path.Combine(tempDir, "merged.gif");
-            method.Invoke(null, new object?[] { collections, outputPath, form, false });
+            method.Invoke(null, new object?[] { collections, outputPath, form, false, ResourceLimits.Memory, ResourceLimits.Disk });
 
             using var merged = new MagickImageCollection(outputPath);
             Assert.Equal(766, (int)merged[0].Width);


### PR DESCRIPTION
## Summary
- allow MergeGifsHorizontally to accept memory and disk limits in bytes
- pass configured ImageMagick resource limits when merging GIFs
- update tests to supply resource limits and document expected units

## Testing
- `dotnet test` *(fails: Assert.Equal() Failure Expected: 150 Actual: 1)*

------
https://chatgpt.com/codex/tasks/task_e_68b4ec167004833087098971ef2ef53e