### PR TITLE
Show ImageMagick resource limits in UI

### DIFF
--- a/GTMainForm.Designer.cs
+++ b/GTMainForm.Designer.cs
@@ -491,7 +491,7 @@
             lblResourceLimitDesc.Name = "lblResourceLimitDesc";
             lblResourceLimitDesc.Size = new System.Drawing.Size(234, 15);
             lblResourceLimitDesc.TabIndex = 15;
-            lblResourceLimitDesc.Text = "Resource limit: mem: ?? MB / disk: ?? MB";
+            lblResourceLimitDesc.Text = string.Format(SteamGifCropper.Properties.Resources.Label_ResourceLimitDesc, "??", "??");
             // 
             // GifToolMainForm
             // 

--- a/GTMainForm.Designer.cs
+++ b/GTMainForm.Designer.cs
@@ -491,7 +491,7 @@
             lblResourceLimitDesc.Name = "lblResourceLimitDesc";
             lblResourceLimitDesc.Size = new System.Drawing.Size(234, 15);
             lblResourceLimitDesc.TabIndex = 15;
-            lblResourceLimitDesc.Text = string.Format(SteamGifCropper.Properties.Resources.Label_ResourceLimitDesc, "??", "??");
+            lblResourceLimitDesc.Text = "Resource limit: mem: ?? MB / disk: ?? MB";
             // 
             // GifToolMainForm
             // 

--- a/GTMainForm.cs
+++ b/GTMainForm.cs
@@ -5,6 +5,7 @@ using System.Drawing;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 using Microsoft.Win32;
+using ImageMagick;
 
 namespace GifProcessorApp
 {
@@ -37,6 +38,8 @@ namespace GifProcessorApp
 
                 // Register for theme changes
                 SystemEvents.UserPreferenceChanged += SystemEvents_UserPreferenceChanged;
+
+                UpdateResourceLimitLabel();
             }
             catch (Exception ex)
             {
@@ -316,12 +319,28 @@ namespace GifProcessorApp
                     lblStatus.Text = SteamGifCropper.Properties.Resources.Status_Ready;
                 }
 
+                UpdateResourceLimitLabel();
+
                 this.Invalidate(true);
                 this.Update();
             }
             catch (Exception ex)
             {
                 System.Diagnostics.Debug.WriteLine($"Failed to update UI text: {ex.Message}");
+            }
+        }
+
+        private void UpdateResourceLimitLabel()
+        {
+            try
+            {
+                ulong memMb = ResourceLimits.Memory / (1024UL * 1024UL);
+                ulong diskMb = ResourceLimits.Disk / (1024UL * 1024UL);
+                lblResourceLimitDesc.Text = string.Format(SteamGifCropper.Properties.Resources.Label_ResourceLimitDesc, memMb, diskMb);
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"Failed to update resource limit label: {ex.Message}");
             }
         }
 

--- a/Properties/Resources.Designer.cs
+++ b/Properties/Resources.Designer.cs
@@ -1157,6 +1157,15 @@ namespace SteamGifCropper.Properties {
                 return ResourceManager.GetString("Label_GifsicleNotice", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Resource limit: mem: {0} MB / disk: {1} MB.
+        /// </summary>
+        internal static string Label_ResourceLimitDesc {
+            get {
+                return ResourceManager.GetString("Label_ResourceLimitDesc", resourceCulture);
+            }
+        }
         
         /// <summary>
         ///   Looks up a localized string similar to Please select 2-5 GIF files to merge (in order from left to right):.

--- a/Properties/Resources.ja.resx
+++ b/Properties/Resources.ja.resx
@@ -524,6 +524,9 @@
   <data name="Label_GifsicleNotice" xml:space="preserve">
     <value>注意：gifsicle.exe は「システム PATH」に存在する必要があります</value>
   </data>
+  <data name="Label_ResourceLimitDesc" xml:space="preserve">
+    <value>リソース制限: メモリ {0} MB / ディスク {1} MB</value>
+  </data>
   <data name="MergeDialog_Instructions" xml:space="preserve">
     <value>マージする2-5個のGIFファイルを選択してください（左から右の順序で）：</value>
   </data>

--- a/Properties/Resources.resx
+++ b/Properties/Resources.resx
@@ -516,6 +516,9 @@
   <data name="Label_GifsicleNotice" xml:space="preserve">
     <value>Notice: gifsicle.exe must be in the "System PATH"</value>
   </data>
+  <data name="Label_ResourceLimitDesc" xml:space="preserve">
+    <value>Resource limit: mem: {0} MB / disk: {1} MB</value>
+  </data>
   <data name="MergeDialog_Instructions" xml:space="preserve">
     <value>Please select 2-5 GIF files to merge (in order from left to right):</value>
   </data>

--- a/Properties/Resources.zh-TW.resx
+++ b/Properties/Resources.zh-TW.resx
@@ -524,6 +524,9 @@
   <data name="Label_GifsicleNotice" xml:space="preserve">
     <value>注意：gifsicle.exe 必須位於「系統 PATH」中</value>
   </data>
+  <data name="Label_ResourceLimitDesc" xml:space="preserve">
+    <value>資源限制：記憶體 {0} MB / 磁碟 {1} MB</value>
+  </data>
   <data name="MergeDialog_Instructions" xml:space="preserve">
     <value>請選擇2-5個GIF檔案進行合併（順序為由左至右）：</value>
   </data>


### PR DESCRIPTION
## Summary
- add localized `Label_ResourceLimitDesc` string for resource limit display
- compute and update resource limit label from `ImageMagick.ResourceLimits`

## Testing
- `dotnet test --no-build` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5016fddb083308cec4f35cb702b69