### PR TITLE
Use resource string for merge dialog instructions

### DIFF
--- a/MergeGifsDialog.cs
+++ b/MergeGifsDialog.cs
@@ -159,7 +159,7 @@ namespace GifProcessorApp
             lblInstructions.Name = "lblInstructions";
             lblInstructions.Size = new System.Drawing.Size(371, 22);
             lblInstructions.TabIndex = 0;
-            lblInstructions.Text = "Please select 2-5 GIF files to merge (in order from left to right):";
+            lblInstructions.Text = SteamGifCropper.Properties.Resources.MergeDialog_Instructions;
             // 
             // lblGifFiles
             // 


### PR DESCRIPTION
## Summary
- use translated resource for Merge GIFs dialog instructions

## Testing
- `dotnet test` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b5031d39008330a96963799f09a913