### PR TITLE
Avoid disposing cropped frames prematurely

### DIFF
--- a/GifProcessor.cs
+++ b/GifProcessor.cs
@@ -188,31 +188,30 @@ namespace GifProcessorApp
 
                         mainForm.lblStatus.Text = string.Format(SteamGifCropper.Properties.Resources.Status_ProcessingPart, i + 1, (currentFrame % collection.Count) + 1);
                         Application.DoEvents();
-                            
-                            // Create new image with correct dimensions
-                            using (var newImage = new MagickImage(MagickColors.Transparent, (uint)copyWidth, (uint)newHeight))
-                            {
-                                // Crop the frame to the specific range
-                                var cropGeometry = new MagickGeometry(ranges[i].Start, 0, (uint)copyWidth, (uint)canvasHeight);
-                                using (var croppedFrame = frame.Clone())
-                                {
-                                    croppedFrame.Crop(cropGeometry);
-                                    croppedFrame.ResetPage();
-                                    
-                                    // Composite the cropped frame onto the new image
-                                    newImage.Composite(croppedFrame, 0, 0, CompositeOperator.Over);
-                                }
-                                
-                                // Set animation delay to target framerate
-                                newImage.AnimationDelay = targetDelay;
-                                newImage.GifDisposeMethod = GifDisposeMethod.Background;
-                                
-                                partCollection.Add(newImage.Clone());
-                            }
 
-                            currentFrame++;
-                            UpdateFrameProgress(mainForm, currentFrame, totalFrames);
+                        // Create new image with correct dimensions
+                        var newImage = new MagickImage(MagickColors.Transparent, (uint)copyWidth, (uint)newHeight);
+
+                        // Crop the frame to the specific range
+                        var cropGeometry = new MagickGeometry(ranges[i].Start, 0, (uint)copyWidth, (uint)canvasHeight);
+                        using (var croppedFrame = frame.Clone())
+                        {
+                            croppedFrame.Crop(cropGeometry);
+                            croppedFrame.ResetPage();
+
+                            // Composite the cropped frame onto the new image
+                            newImage.Composite(croppedFrame, 0, 0, CompositeOperator.Over);
                         }
+
+                        // Set animation delay to target framerate
+                        newImage.AnimationDelay = targetDelay;
+                        newImage.GifDisposeMethod = GifDisposeMethod.Background;
+
+                        partCollection.Add(newImage);
+
+                        currentFrame++;
+                        UpdateFrameProgress(mainForm, currentFrame, totalFrames);
+                    }
 
                         string outputFile = $"{Path.GetFileNameWithoutExtension(inputFilePath)}_Part{i + 1}.gif";
                         string outputDir = Path.GetDirectoryName(inputFilePath);


### PR DESCRIPTION
## Summary
- Avoid cloning cropped frames in `SplitGif` and add them directly to the collection
- Keep `MagickImage` alive until the collection is written to prevent premature disposal

## Testing
- `dotnet test` *(fails: LargeGif_RespectsResourceLimits, MergeMultipleGifs_UsingSampleGifs_MergesCorrectly, MergeGifsHorizontally_UsingSampleGifs_MergesCorrectly)*

------
https://chatgpt.com/codex/tasks/task_e_68b50904b9608330bdc919f589de2a4b