### PR TITLE
Clamp progress bar max to 100 for GIF batch operations

### DIFF
--- a/GifProcessor.cs
+++ b/GifProcessor.cs
@@ -1054,7 +1054,7 @@ namespace GifProcessorApp
                 {
                     UpdateStatusLabel(mainForm, SteamGifCropper.Properties.Resources.Status_RestoringTailBytes);
                     mainForm.pBarTaskStatus.Value = 0;
-                    mainForm.pBarTaskStatus.Maximum = selectedFiles.Length;
+                    mainForm.pBarTaskStatus.Maximum = 100;
                     mainForm.pBarTaskStatus.Visible = true;
 
                     int progress = 0;
@@ -1163,7 +1163,7 @@ namespace GifProcessorApp
                 {
                     mainForm.pBarTaskStatus.Visible = true;
                     mainForm.pBarTaskStatus.Value = 0;
-                    mainForm.pBarTaskStatus.Maximum = filePaths.Length;
+                    mainForm.pBarTaskStatus.Maximum = 100;
 
                     foreach (string filePath in filePaths)
                     {


### PR DESCRIPTION
## Summary
- Avoid Value-out-of-range errors when updating the task status bar by capping the maximum at 100 for batch GIF tail-byte operations

## Testing
- `dotnet test -p:EnableWindowsTargeting=true` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*


------
https://chatgpt.com/codex/tasks/task_e_68b59194c3248330b67ea543202af5ba