### PR TITLE
Preserve frame timing when splitting GIFs

### DIFF
--- a/GifProcessor.cs
+++ b/GifProcessor.cs
@@ -196,10 +196,6 @@ namespace GifProcessorApp
             collection.Coalesce();
             int newHeight = canvasHeight + HeightExtension;
             
-            // Calculate target frame delay in centiseconds (1/100th of a second)
-            // For 15fps: 100/15 ≈ 6.67 centiseconds, rounded to 7
-            uint targetDelay = (uint)Math.Round(100.0 / targetFramerate);
-
             int totalFrames = collection.Count * ranges.Length;
             int currentFrame = 0;
 
@@ -230,8 +226,9 @@ namespace GifProcessorApp
                             newImage.Composite(croppedFrame, 0, 0, CompositeOperator.Over);
                         }
 
-                        // Set animation delay to target framerate
-                        newImage.AnimationDelay = targetDelay;
+                        // Preserve animation timing from source frame
+                        newImage.AnimationDelay = frame.AnimationDelay;
+                        newImage.AnimationTicksPerSecond = frame.AnimationTicksPerSecond;
                         newImage.GifDisposeMethod = GifDisposeMethod.Background;
 
                         partCollection.Add(newImage);
@@ -745,8 +742,6 @@ namespace GifProcessorApp
             var ranges = GetCropRanges(canvasWidth);
             int canvasHeight = (int)collection[0].Height;
             int newHeight = canvasHeight + HeightExtension;
-            uint targetDelay = (uint)Math.Round(100.0 / targetFramerate);
-
             Directory.CreateDirectory(outputDirectory);
 
             for (int i = 0; i < ranges.Length; i++)
@@ -762,7 +757,8 @@ namespace GifProcessorApp
                     croppedFrame.Crop(cropGeometry);
                     croppedFrame.ResetPage();
                     newImage.Composite(croppedFrame, 0, 0, CompositeOperator.Over);
-                    newImage.AnimationDelay = targetDelay;
+                    newImage.AnimationDelay = frame.AnimationDelay;
+                    newImage.AnimationTicksPerSecond = frame.AnimationTicksPerSecond;
                     newImage.GifDisposeMethod = GifDisposeMethod.Background;
                     partCollection.Add(newImage.Clone());
                 }

--- a/SteamGifCropper.Tests/GifProcessorMagickTests.cs
+++ b/SteamGifCropper.Tests/GifProcessorMagickTests.cs
@@ -52,6 +52,29 @@ public class GifProcessorMagickTests
         }
     }
 
+    [Fact]
+    public void SplitGif_PartsPreserveAnimationTiming()
+    {
+        string tempDir = Directory.CreateTempSubdirectory().FullName;
+        string input = GifTestHelper.CreateGradientGif(tempDir, 766, 100, 2, "red", "black");
+        try
+        {
+            using var original = new MagickImageCollection(input);
+            GifProcessor.SplitGif(input, tempDir);
+            string partPath = Path.Combine(tempDir, $"{Path.GetFileNameWithoutExtension(input)}_Part1.gif");
+            using var part = new MagickImageCollection(partPath);
+            for (int i = 0; i < original.Count; i++)
+            {
+                Assert.Equal(original[i].AnimationDelay, part[i].AnimationDelay);
+                Assert.Equal(original[i].AnimationTicksPerSecond, part[i].AnimationTicksPerSecond);
+            }
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
     private static bool EnsureGif(string path, int width, int height)
     {
         if (File.Exists(path))


### PR DESCRIPTION
## Summary
- Copy each source frame's AnimationDelay and AnimationTicksPerSecond when splitting GIFs
- Add test to confirm split parts inherit original frame timing

## Testing
- `dotnet test` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b59813bf208330830a8c8a40d93829