### PR TITLE
Fix restoration message newlines

### DIFF
--- a/GifProcessor.cs
+++ b/GifProcessor.cs
@@ -1149,7 +1149,8 @@ namespace GifProcessorApp
 
                     string resultMessage = string.Format(
                         SteamGifCropper.Properties.Resources.Message_RestorationComplete,
-                        processedCount, skippedCount);
+                        processedCount, skippedCount)
+                        .Replace("\n", Environment.NewLine);
 
                     WindowsThemeManager.ShowThemeAwareMessageBox(mainForm,
                                     resultMessage,

--- a/Properties/Resources.ja.resx
+++ b/Properties/Resources.ja.resx
@@ -294,7 +294,7 @@
     <value>{1} 個のGIFファイルのうち {0} 個が正常に処理されました！</value>
   </data>
   <data name="Message_RestorationComplete" xml:space="preserve">
-    <value>復元が完了しました！\n処理されたファイル: {0}\nスキップされたファイル (0x21 ではない): {1}</value>
+    <value>復元が完了しました！&#xA;処理されたファイル: {0}&#xA;スキップされたファイル (0x21 ではない): {1}</value>
   </data>
   <data name="Error_UnsupportedWidth" xml:space="preserve">
     <value>サポートされていないGIF幅：{0}ピクセル。このツールは{1}ピクセルまたは{2}ピクセル幅のGIFファイルのみサポートしています。</value>

--- a/Properties/Resources.resx
+++ b/Properties/Resources.resx
@@ -292,7 +292,7 @@
     <value>{0} of {1} GIF files processed successfully!</value>
   </data>
   <data name="Message_RestorationComplete" xml:space="preserve">
-    <value>Restoration completed!\nFiles processed: {0}\nFiles skipped (not 0x21): {1}</value>
+    <value>Restoration completed!&#xA;Files processed: {0}&#xA;Files skipped (not 0x21): {1}</value>
   </data>
   <data name="Error_UnsupportedWidth" xml:space="preserve">
     <value>Unsupported GIF canvas width: {0}px. Only {1}px and {2}px are supported.</value>

--- a/Properties/Resources.zh-TW.resx
+++ b/Properties/Resources.zh-TW.resx
@@ -294,7 +294,7 @@
     <value>{1} 個 GIF 檔案中的 {0} 個已成功處理！</value>
   </data>
   <data name="Message_RestorationComplete" xml:space="preserve">
-    <value>還原已完成！\n已處理檔案: {0}\n已略過檔案 (非 0x21): {1}</value>
+    <value>還原已完成！&#xA;已處理檔案: {0}&#xA;已略過檔案 (非 0x21): {1}</value>
   </data>
   <data name="Error_UnsupportedWidth" xml:space="preserve">
     <value>不支援的GIF寬度：{0}像素。此工具只支援{1}像素或{2}像素寬度的GIF檔案。</value>


### PR DESCRIPTION
## Summary
- Replace literal `\n` in restoration-complete messages with actual line breaks
- Normalize restoration-complete message formatting using `Environment.NewLine`

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5afb47fb48330887cf1eaa331bda6