### PR TITLE
Reset progress bar before saving parts

### DIFF
--- a/GifProcessor.cs
+++ b/GifProcessor.cs
@@ -277,6 +277,9 @@ namespace GifProcessorApp
 
                         UpdateStatusLabel(mainForm, SteamGifCropper.Properties.Resources.Status_Saving);
 
+                        mainForm.pBarTaskStatus.Visible = true;
+                        mainForm.pBarTaskStatus.Value = 0;
+
                         partCollection.Write(outputPath);
 
                         if (mainForm.chkGifsicle.Checked)
@@ -297,6 +300,11 @@ namespace GifProcessorApp
                             });
 
                             GifsicleWrapper.OptimizeGif(outputPath, outputPath, options, progress).GetAwaiter().GetResult();
+                        }
+                        else
+                        {
+                            UpdateProgress(mainForm.pBarTaskStatus, 100, 100);
+                            UpdateStatusLabel(mainForm, $"Saving part {i + 1} complete");
                         }
 
                         ModifyGifFile(outputPath, canvasHeight);


### PR DESCRIPTION
## Summary
- ensure task progress bar is shown and reset before saving each GIF part
- mark conversion complete with 100% progress and completion message when Gifsicle optimization is disabled

## Testing
- `dotnet build -p:EnableWindowsTargeting=true` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*
- `dotnet test SteamGifCropper.Tests/SteamGifCropper.Tests.csproj` *(fails: SplitGif_PartsPreserveAnimationTiming)*
- `dotnet test SteamGifCropper.Tests/SteamGifCropper.Tests.csproj --filter SplitGif_ReportsExpectedProgress`


------
https://chatgpt.com/codex/tasks/task_e_68b5b1dd29c08330a7b1bc05015ff9f2