### PR TITLE
Localize split GIF FPS label

### DIFF
--- a/GTMainForm.Designer.cs
+++ b/GTMainForm.Designer.cs
@@ -386,8 +386,8 @@
             lblFPS.Name = "lblFPS";
             lblFPS.Size = new System.Drawing.Size(24, 15);
             lblFPS.TabIndex = 14;
-            lblFPS.Text = "fps";
-            // 
+            lblFPS.Text = SteamGifCropper.Properties.Resources.Label_FPS;
+            //
             // btnMerge2to5GifToOne
             // 
             btnMerge2to5GifToOne.Location = new System.Drawing.Point(313, 7);

--- a/Properties/Resources.Designer.cs
+++ b/Properties/Resources.Designer.cs
@@ -349,7 +349,7 @@ namespace SteamGifCropper.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to fps.
+        ///   Looks up a localized string similar to fps for split GIF.
         /// </summary>
         internal static string Label_FPS {
             get {

--- a/Properties/Resources.ja.resx
+++ b/Properties/Resources.ja.resx
@@ -411,7 +411,7 @@
     <value>ターゲットフレームレート：</value>
   </data>
   <data name="Label_FPS" xml:space="preserve">
-    <value>fps</value>
+    <value>fps for split GIF.</value>
   </data>
   <data name="Tooltip_Framerate" xml:space="preserve">
     <value>すべての出力GIFのターゲットフレームレート(1-60 fps)</value>

--- a/Properties/Resources.resx
+++ b/Properties/Resources.resx
@@ -403,7 +403,7 @@
     <value>Target framerate:</value>
   </data>
   <data name="Label_FPS" xml:space="preserve">
-    <value>fps</value>
+    <value>fps for split GIF.</value>
   </data>
   <data name="Tooltip_Framerate" xml:space="preserve">
     <value>Target framerate for all GIF outputs (frames per second)</value>

--- a/Properties/Resources.zh-TW.resx
+++ b/Properties/Resources.zh-TW.resx
@@ -411,7 +411,7 @@
     <value>目標幀率：</value>
   </data>
   <data name="Label_FPS" xml:space="preserve">
-    <value>fps</value>
+    <value>fps for split GIF.</value>
   </data>
   <data name="Tooltip_Framerate" xml:space="preserve">
     <value>所有輸出GIF的目標幀率(1-60 fps)</value>


### PR DESCRIPTION
## Summary
- localize split GIF FPS label via Resources

## Testing
- `dotnet test` *(fails: MSB4019 WindowsDesktop targets missing; SplitGif_PartsPreserveAnimationTiming assertion failure)*

------
https://chatgpt.com/codex/tasks/task_e_68b5b1f186dc8330858fe37a1aecb6b1