### PR TITLE
feat(effects): rain overlay + A->B morph transitions (raindrop / tile flip)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,14 +118,22 @@ Each dialog handles one specific operation type:
 - `QuicksandDialog` - Horizontal/vertical viscous band flow (image / GIF)
 - `RippleDialog` - Water ripple: up to 3 interfering drops (image / GIF)
 - `RippleDropPickerForm` - Click-to-pick a ripple drop position on frame 0
+- `WindDialog` - Wind sway (風吹麥田): travelling-wave displacement, normal/nuclear modes (image / GIF)
+- `RainDialog` - Rain overlay: translucent slanted streaks, wind + "rain stops" fade-out (image / GIF)
+- `MorphTransitionDialog` - A→B morph transition (raindrop-spread reveal / tile flip) with a pre-roll + remaining-B timeline
 
 > **Creative-effects detail:** these "766px single-output, chainable" effects (grid mosaic, slot
-> machine, quicksand, ripple) — their ideas and completion status live in
+> machine, quicksand, ripple, wind, rain, A→B morph) — their ideas and completion status live in
 > `docs/CreativeFeatureIdeas.md`; the detailed implementation/handoff dev log (file lists, commits,
 > semantics, gotchas) lives in `docs/CreativeEffectsDevLog.md`.
 > Their math is extracted into pure, dependency-free files for unit testing — `SlotMachineGeometry.cs`,
-> `QuicksandGeometry.cs`, `GifEffectWindow.cs`, `GridMosaicGeometry.cs`, `RippleField.cs` (+ the
-> Magick-side `RippleRenderer.cs`, `GridMosaicRenderer.cs`) — linked into the test project.
+> `QuicksandGeometry.cs`, `GifEffectWindow.cs`, `GridMosaicGeometry.cs`, `RippleField.cs`,
+> `WindField.cs`, `RainField.cs`, `RaindropRevealField.cs`, `TileFlipGeometry.cs`, `MorphSettings.cs`
+> (`MorphTimeline`) (+ the Magick-side `RippleRenderer.cs`, `GridMosaicRenderer.cs`,
+> `RaindropRevealRenderer.cs`, `TileFlipRenderer.cs`) — linked into the test project (pure files only).
+> The A→B morph uses its own `pre-roll + morph window + remaining-B` timeline (total = pre-roll + B
+> duration), distinct from the concat overlap model; it lives in `GifProcessor.Morph.cs` /
+> `MorphTransitionDialog`, not in `TransitionGenerator`.
 
 ### Magick.NET (ImageMagick) Integration
 
@@ -310,7 +318,13 @@ SteamGifCropper/
 │   │   ├── GridMosaicSettings/Geometry/Renderer.cs   # Grid mosaic (geometry pure, renderer Magick)
 │   │   ├── SlotMachineSettings/Geometry.cs           # Slot machine (geometry pure)
 │   │   ├── QuicksandSettings/Geometry.cs             # Quicksand flow (geometry pure)
-│   │   └── RippleSettings/Field/Renderer.cs          # Water ripple (Field pure, Renderer Magick)
+│   │   ├── RippleSettings/Field/Renderer.cs          # Water ripple (Field pure, Renderer Magick)
+│   │   ├── WindSettings/Field/Renderer.cs            # Wind sway (Field pure, Renderer Magick)
+│   │   ├── RainSettings/Field/Renderer.cs            # Rain overlay (Field pure, Renderer draws streaks into RGBA buffer)
+│   │   ├── MorphSettings.cs                          # A→B morph settings + MorphTimeline (pure)
+│   │   ├── RaindropRevealField/Renderer.cs           # Morph raindrop reveal (Field pure, Renderer Magick)
+│   │   ├── TileFlipGeometry/Renderer.cs              # Morph tile flip (Geometry pure, Renderer Magick)
+│   │   └── GifProcessor.{Rain,Morph,Wind,...}.cs     # Per-effect engine partials (RunXxx + Build*)
 │   ├── Forms/
 │   │   ├── GTMainForm.cs                   # Main UI form
 │   │   ├── GTMainForm.Designer.cs
@@ -327,7 +341,10 @@ SteamGifCropper/
 │   │   ├── SlotMachineDialog.cs
 │   │   ├── QuicksandDialog.cs
 │   │   ├── RippleDialog.cs
-│   │   └── RippleDropPickerForm.cs         # Click-to-pick ripple drop position
+│   │   ├── RippleDropPickerForm.cs         # Click-to-pick ripple drop position
+│   │   ├── WindDialog.cs
+│   │   ├── RainDialog.cs                   # Rain overlay (translucent streaks)
+│   │   └── MorphTransitionDialog.cs        # A→B morph (raindrop reveal / tile flip)
 │   └── Platform/                           # Windows integration
 │       ├── WindowsThemeManager.cs
 │       └── RegistryProvider.cs

--- a/Properties/Resources.Designer.cs
+++ b/Properties/Resources.Designer.cs
@@ -2417,6 +2417,222 @@ namespace SteamGifCropper.Properties {
             }
         }
 
+        internal static string Button_RainStatic {
+            get {
+                return ResourceManager.GetString("Button_RainStatic", resourceCulture);
+            }
+        }
+
+        internal static string Button_RainGif {
+            get {
+                return ResourceManager.GetString("Button_RainGif", resourceCulture);
+            }
+        }
+
+        internal static string Status_RainBuilding {
+            get {
+                return ResourceManager.GetString("Status_RainBuilding", resourceCulture);
+            }
+        }
+
+        internal static string RainDialog_Title {
+            get {
+                return ResourceManager.GetString("RainDialog_Title", resourceCulture);
+            }
+        }
+
+        internal static string RainDialog_RainAmount {
+            get {
+                return ResourceManager.GetString("RainDialog_RainAmount", resourceCulture);
+            }
+        }
+
+        internal static string RainDialog_WindDir {
+            get {
+                return ResourceManager.GetString("RainDialog_WindDir", resourceCulture);
+            }
+        }
+
+        internal static string RainDialog_WindStrength {
+            get {
+                return ResourceManager.GetString("RainDialog_WindStrength", resourceCulture);
+            }
+        }
+
+        internal static string RainDialog_DropLength {
+            get {
+                return ResourceManager.GetString("RainDialog_DropLength", resourceCulture);
+            }
+        }
+
+        internal static string RainDialog_FadeOut {
+            get {
+                return ResourceManager.GetString("RainDialog_FadeOut", resourceCulture);
+            }
+        }
+
+        internal static string RainDialog_FadeSeconds {
+            get {
+                return ResourceManager.GetString("RainDialog_FadeSeconds", resourceCulture);
+            }
+        }
+
+        internal static string RainDialog_GifPlayDuring {
+            get {
+                return ResourceManager.GetString("RainDialog_GifPlayDuring", resourceCulture);
+            }
+        }
+
+        internal static string RainDialog_GifFreeze {
+            get {
+                return ResourceManager.GetString("RainDialog_GifFreeze", resourceCulture);
+            }
+        }
+
+        internal static string RainDir_None {
+            get {
+                return ResourceManager.GetString("RainDir_None", resourceCulture);
+            }
+        }
+
+        internal static string RainDir_Left {
+            get {
+                return ResourceManager.GetString("RainDir_Left", resourceCulture);
+            }
+        }
+
+        internal static string RainDir_Right {
+            get {
+                return ResourceManager.GetString("RainDir_Right", resourceCulture);
+            }
+        }
+
+        internal static string Button_MorphTransition {
+            get {
+                return ResourceManager.GetString("Button_MorphTransition", resourceCulture);
+            }
+        }
+
+        internal static string Status_MorphBuilding {
+            get {
+                return ResourceManager.GetString("Status_MorphBuilding", resourceCulture);
+            }
+        }
+
+        internal static string MorphDialog_Title {
+            get {
+                return ResourceManager.GetString("MorphDialog_Title", resourceCulture);
+            }
+        }
+
+        internal static string MorphDialog_InputA {
+            get {
+                return ResourceManager.GetString("MorphDialog_InputA", resourceCulture);
+            }
+        }
+
+        internal static string MorphDialog_InputB {
+            get {
+                return ResourceManager.GetString("MorphDialog_InputB", resourceCulture);
+            }
+        }
+
+        internal static string MorphDialog_Style {
+            get {
+                return ResourceManager.GetString("MorphDialog_Style", resourceCulture);
+            }
+        }
+
+        internal static string MorphStyle_Raindrop {
+            get {
+                return ResourceManager.GetString("MorphStyle_Raindrop", resourceCulture);
+            }
+        }
+
+        internal static string MorphStyle_TileFlip {
+            get {
+                return ResourceManager.GetString("MorphStyle_TileFlip", resourceCulture);
+            }
+        }
+
+        internal static string MorphDialog_PreRoll {
+            get {
+                return ResourceManager.GetString("MorphDialog_PreRoll", resourceCulture);
+            }
+        }
+
+        internal static string MorphDialog_MorphSeconds {
+            get {
+                return ResourceManager.GetString("MorphDialog_MorphSeconds", resourceCulture);
+            }
+        }
+
+        internal static string MorphDialog_RainIntensity {
+            get {
+                return ResourceManager.GetString("MorphDialog_RainIntensity", resourceCulture);
+            }
+        }
+
+        internal static string MorphDialog_DropSizeVar {
+            get {
+                return ResourceManager.GetString("MorphDialog_DropSizeVar", resourceCulture);
+            }
+        }
+
+        internal static string MorphDialog_SpreadRadius {
+            get {
+                return ResourceManager.GetString("MorphDialog_SpreadRadius", resourceCulture);
+            }
+        }
+
+        internal static string MorphDialog_SoftEdge {
+            get {
+                return ResourceManager.GetString("MorphDialog_SoftEdge", resourceCulture);
+            }
+        }
+
+        internal static string MorphDialog_Divisions {
+            get {
+                return ResourceManager.GetString("MorphDialog_Divisions", resourceCulture);
+            }
+        }
+
+        internal static string MorphDialog_FlipDir {
+            get {
+                return ResourceManager.GetString("MorphDialog_FlipDir", resourceCulture);
+            }
+        }
+
+        internal static string FlipDir_Random {
+            get {
+                return ResourceManager.GetString("FlipDir_Random", resourceCulture);
+            }
+        }
+
+        internal static string FlipDir_Up {
+            get {
+                return ResourceManager.GetString("FlipDir_Up", resourceCulture);
+            }
+        }
+
+        internal static string FlipDir_Down {
+            get {
+                return ResourceManager.GetString("FlipDir_Down", resourceCulture);
+            }
+        }
+
+        internal static string FlipDir_Left {
+            get {
+                return ResourceManager.GetString("FlipDir_Left", resourceCulture);
+            }
+        }
+
+        internal static string FlipDir_Right {
+            get {
+                return ResourceManager.GetString("FlipDir_Right", resourceCulture);
+            }
+        }
+
         internal static string Warn_LargeMemoryTitle {
             get {
                 return ResourceManager.GetString("Warn_LargeMemoryTitle", resourceCulture);

--- a/Properties/Resources.ja.resx
+++ b/Properties/Resources.ja.resx
@@ -412,7 +412,7 @@
     <value>流砂アニメーションを生成中…</value>
   </data>
   <data name="QuickDialog_Title" xml:space="preserve">
-    <value>流砂フロー（766px）</value>
+    <value>流砂フロー</value>
   </data>
   <data name="QuickDialog_InputLabel" xml:space="preserve">
     <value>入力画像または GIF</value>
@@ -484,7 +484,7 @@
     <value>水波紋を生成中…</value>
   </data>
   <data name="RippleDialog_Title" xml:space="preserve">
-    <value>水波紋（766px）</value>
+    <value>水波紋</value>
   </data>
   <data name="RippleDialog_WaveSpeed" xml:space="preserve">
     <value>波速</value>
@@ -1202,7 +1202,7 @@ FFmpeg 出力（切り捨て）:
     <value>風効果を生成中…</value>
   </data>
   <data name="WindDialog_Title" xml:space="preserve">
-    <value>風効果（766px）</value>
+    <value>風効果</value>
   </data>
   <data name="WindDialog_Direction" xml:space="preserve">
     <value>風向</value>
@@ -1294,6 +1294,12 @@ FFmpeg 出力（切り捨て）:
   <data name="WindDialog_GifFreeze" xml:space="preserve">
     <value>最初のフレームで固定</value>
   </data>
+  <data name="RainDialog_GifPlayDuring" xml:space="preserve">
+    <value>再生に雨を重ねる</value>
+  </data>
+  <data name="RainDialog_GifFreeze" xml:space="preserve">
+    <value>最初のフレームで固定</value>
+  </data>
   <data name="Dialog_KeepOriginalSize" xml:space="preserve">
     <value>元のサイズを維持（766pxに縮小しない）</value>
   </data>
@@ -1302,5 +1308,107 @@ FFmpeg 出力（切り捨て）:
   </data>
   <data name="Warn_LargeMemory" xml:space="preserve">
     <value>{1}×{2}、{3} フレームで処理し、約 {0} MB のメモリを使用します。遅くなるかメモリ不足になる可能性があります。続行しますか？</value>
+  </data>
+  <data name="Button_RainStatic" xml:space="preserve">
+    <value>雨エフェクト（画像）</value>
+  </data>
+  <data name="Button_RainGif" xml:space="preserve">
+    <value>雨エフェクト（GIF）</value>
+  </data>
+  <data name="Status_RainBuilding" xml:space="preserve">
+    <value>雨エフェクトを生成中…</value>
+  </data>
+  <data name="RainDialog_Title" xml:space="preserve">
+    <value>雨エフェクト</value>
+  </data>
+  <data name="RainDialog_RainAmount" xml:space="preserve">
+    <value>雨量</value>
+  </data>
+  <data name="RainDialog_WindDir" xml:space="preserve">
+    <value>風向</value>
+  </data>
+  <data name="RainDialog_WindStrength" xml:space="preserve">
+    <value>風の強さ</value>
+  </data>
+  <data name="RainDialog_DropLength" xml:space="preserve">
+    <value>雨筋の長さ</value>
+  </data>
+  <data name="RainDialog_FadeOut" xml:space="preserve">
+    <value>雨上がりフェード</value>
+  </data>
+  <data name="RainDialog_FadeSeconds" xml:space="preserve">
+    <value>フェード秒数</value>
+  </data>
+  <data name="RainDir_None" xml:space="preserve">
+    <value>無風</value>
+  </data>
+  <data name="RainDir_Left" xml:space="preserve">
+    <value>左へ</value>
+  </data>
+  <data name="RainDir_Right" xml:space="preserve">
+    <value>右へ</value>
+  </data>
+  <data name="Button_MorphTransition" xml:space="preserve">
+    <value>重ね変換 A→B（雨だれ／タイル反転）</value>
+  </data>
+  <data name="Status_MorphBuilding" xml:space="preserve">
+    <value>重ね変換を生成中…</value>
+  </data>
+  <data name="MorphDialog_Title" xml:space="preserve">
+    <value>重ね変換 A → B</value>
+  </data>
+  <data name="MorphDialog_InputA" xml:space="preserve">
+    <value>クリップ A（ベース）</value>
+  </data>
+  <data name="MorphDialog_InputB" xml:space="preserve">
+    <value>クリップ B（出現）</value>
+  </data>
+  <data name="MorphDialog_Style" xml:space="preserve">
+    <value>スタイル</value>
+  </data>
+  <data name="MorphStyle_Raindrop" xml:space="preserve">
+    <value>雨だれ拡散</value>
+  </data>
+  <data name="MorphStyle_TileFlip" xml:space="preserve">
+    <value>タイル反転</value>
+  </data>
+  <data name="MorphDialog_PreRoll" xml:space="preserve">
+    <value>先行再生 A（秒）</value>
+  </data>
+  <data name="MorphDialog_MorphSeconds" xml:space="preserve">
+    <value>変換（秒）</value>
+  </data>
+  <data name="MorphDialog_RainIntensity" xml:space="preserve">
+    <value>雨だれ数</value>
+  </data>
+  <data name="MorphDialog_DropSizeVar" xml:space="preserve">
+    <value>サイズ変動 %</value>
+  </data>
+  <data name="MorphDialog_SpreadRadius" xml:space="preserve">
+    <value>拡散半径</value>
+  </data>
+  <data name="MorphDialog_SoftEdge" xml:space="preserve">
+    <value>縁のぼかし</value>
+  </data>
+  <data name="MorphDialog_Divisions" xml:space="preserve">
+    <value>分割数 (X)</value>
+  </data>
+  <data name="MorphDialog_FlipDir" xml:space="preserve">
+    <value>反転方向</value>
+  </data>
+  <data name="FlipDir_Random" xml:space="preserve">
+    <value>ランダム</value>
+  </data>
+  <data name="FlipDir_Up" xml:space="preserve">
+    <value>上</value>
+  </data>
+  <data name="FlipDir_Down" xml:space="preserve">
+    <value>下</value>
+  </data>
+  <data name="FlipDir_Left" xml:space="preserve">
+    <value>左</value>
+  </data>
+  <data name="FlipDir_Right" xml:space="preserve">
+    <value>右</value>
   </data>
 </root>

--- a/Properties/Resources.resx
+++ b/Properties/Resources.resx
@@ -411,7 +411,7 @@ Files skipped (not 0x21): {1}</value>
     <value>Building quicksand flow...</value>
   </data>
   <data name="QuickDialog_Title" xml:space="preserve">
-    <value>Quicksand Flow (766px)</value>
+    <value>Quicksand Flow</value>
   </data>
   <data name="QuickDialog_InputLabel" xml:space="preserve">
     <value>Input image or GIF</value>
@@ -483,7 +483,7 @@ Files skipped (not 0x21): {1}</value>
     <value>Building water ripple...</value>
   </data>
   <data name="RippleDialog_Title" xml:space="preserve">
-    <value>Water Ripple (766px)</value>
+    <value>Water Ripple</value>
   </data>
   <data name="RippleDialog_WaveSpeed" xml:space="preserve">
     <value>Speed</value>
@@ -1201,7 +1201,7 @@ Technical details: {5}</value>
     <value>Building wind sway...</value>
   </data>
   <data name="WindDialog_Title" xml:space="preserve">
-    <value>Wind Sway (766px)</value>
+    <value>Wind Sway</value>
   </data>
   <data name="WindDialog_Direction" xml:space="preserve">
     <value>From</value>
@@ -1293,6 +1293,12 @@ Technical details: {5}</value>
   <data name="WindDialog_GifFreeze" xml:space="preserve">
     <value>Freeze on frame 0</value>
   </data>
+  <data name="RainDialog_GifPlayDuring" xml:space="preserve">
+    <value>Rain over playback</value>
+  </data>
+  <data name="RainDialog_GifFreeze" xml:space="preserve">
+    <value>Freeze on frame 0</value>
+  </data>
   <data name="Dialog_KeepOriginalSize" xml:space="preserve">
     <value>Keep original size (no 766px fit)</value>
   </data>
@@ -1301,5 +1307,107 @@ Technical details: {5}</value>
   </data>
   <data name="Warn_LargeMemory" xml:space="preserve">
     <value>This will process at {1}×{2} for {3} frames, using roughly {0} MB of memory. It may be slow or run out of memory. Continue?</value>
+  </data>
+  <data name="Button_RainStatic" xml:space="preserve">
+    <value>Rain Overlay (Image)</value>
+  </data>
+  <data name="Button_RainGif" xml:space="preserve">
+    <value>Rain Overlay (GIF)</value>
+  </data>
+  <data name="Status_RainBuilding" xml:space="preserve">
+    <value>Building rain overlay...</value>
+  </data>
+  <data name="RainDialog_Title" xml:space="preserve">
+    <value>Rain Overlay</value>
+  </data>
+  <data name="RainDialog_RainAmount" xml:space="preserve">
+    <value>Rain amount</value>
+  </data>
+  <data name="RainDialog_WindDir" xml:space="preserve">
+    <value>Wind</value>
+  </data>
+  <data name="RainDialog_WindStrength" xml:space="preserve">
+    <value>Strength</value>
+  </data>
+  <data name="RainDialog_DropLength" xml:space="preserve">
+    <value>Streak len</value>
+  </data>
+  <data name="RainDialog_FadeOut" xml:space="preserve">
+    <value>Rain stops (fade out)</value>
+  </data>
+  <data name="RainDialog_FadeSeconds" xml:space="preserve">
+    <value>Fade (s)</value>
+  </data>
+  <data name="RainDir_None" xml:space="preserve">
+    <value>None</value>
+  </data>
+  <data name="RainDir_Left" xml:space="preserve">
+    <value>Left</value>
+  </data>
+  <data name="RainDir_Right" xml:space="preserve">
+    <value>Right</value>
+  </data>
+  <data name="Button_MorphTransition" xml:space="preserve">
+    <value>Morph A→B (Raindrop / Tile Flip)</value>
+  </data>
+  <data name="Status_MorphBuilding" xml:space="preserve">
+    <value>Building morph transition...</value>
+  </data>
+  <data name="MorphDialog_Title" xml:space="preserve">
+    <value>Morph A → B</value>
+  </data>
+  <data name="MorphDialog_InputA" xml:space="preserve">
+    <value>Clip A (base)</value>
+  </data>
+  <data name="MorphDialog_InputB" xml:space="preserve">
+    <value>Clip B (reveal)</value>
+  </data>
+  <data name="MorphDialog_Style" xml:space="preserve">
+    <value>Style</value>
+  </data>
+  <data name="MorphStyle_Raindrop" xml:space="preserve">
+    <value>Raindrop spread</value>
+  </data>
+  <data name="MorphStyle_TileFlip" xml:space="preserve">
+    <value>Tile flip</value>
+  </data>
+  <data name="MorphDialog_PreRoll" xml:space="preserve">
+    <value>Pre-roll A (s)</value>
+  </data>
+  <data name="MorphDialog_MorphSeconds" xml:space="preserve">
+    <value>Morph (s)</value>
+  </data>
+  <data name="MorphDialog_RainIntensity" xml:space="preserve">
+    <value>Drops</value>
+  </data>
+  <data name="MorphDialog_DropSizeVar" xml:space="preserve">
+    <value>Size var %</value>
+  </data>
+  <data name="MorphDialog_SpreadRadius" xml:space="preserve">
+    <value>Spread radius</value>
+  </data>
+  <data name="MorphDialog_SoftEdge" xml:space="preserve">
+    <value>Soft edge</value>
+  </data>
+  <data name="MorphDialog_Divisions" xml:space="preserve">
+    <value>Divisions (X)</value>
+  </data>
+  <data name="MorphDialog_FlipDir" xml:space="preserve">
+    <value>Flip dir</value>
+  </data>
+  <data name="FlipDir_Random" xml:space="preserve">
+    <value>Random</value>
+  </data>
+  <data name="FlipDir_Up" xml:space="preserve">
+    <value>Up</value>
+  </data>
+  <data name="FlipDir_Down" xml:space="preserve">
+    <value>Down</value>
+  </data>
+  <data name="FlipDir_Left" xml:space="preserve">
+    <value>Left</value>
+  </data>
+  <data name="FlipDir_Right" xml:space="preserve">
+    <value>Right</value>
   </data>
 </root>

--- a/Properties/Resources.zh-TW.resx
+++ b/Properties/Resources.zh-TW.resx
@@ -412,7 +412,7 @@
     <value>正在建立流沙流動…</value>
   </data>
   <data name="QuickDialog_Title" xml:space="preserve">
-    <value>流沙流動（766px）</value>
+    <value>流沙流動</value>
   </data>
   <data name="QuickDialog_InputLabel" xml:space="preserve">
     <value>輸入圖片或 GIF</value>
@@ -484,7 +484,7 @@
     <value>正在建立水波紋…</value>
   </data>
   <data name="RippleDialog_Title" xml:space="preserve">
-    <value>水波紋（766px）</value>
+    <value>水波紋</value>
   </data>
   <data name="RippleDialog_WaveSpeed" xml:space="preserve">
     <value>波速</value>
@@ -1202,7 +1202,7 @@ FFmpeg 輸出 (部分)：
     <value>正在建立風吹效果…</value>
   </data>
   <data name="WindDialog_Title" xml:space="preserve">
-    <value>風吹效果（766px）</value>
+    <value>風吹效果</value>
   </data>
   <data name="WindDialog_Direction" xml:space="preserve">
     <value>風從</value>
@@ -1294,6 +1294,12 @@ FFmpeg 輸出 (部分)：
   <data name="WindDialog_GifFreeze" xml:space="preserve">
     <value>定格第一幀</value>
   </data>
+  <data name="RainDialog_GifPlayDuring" xml:space="preserve">
+    <value>雨疊在播放上</value>
+  </data>
+  <data name="RainDialog_GifFreeze" xml:space="preserve">
+    <value>定格第一幀</value>
+  </data>
   <data name="Dialog_KeepOriginalSize" xml:space="preserve">
     <value>保持原始尺寸（不縮到 766px）</value>
   </data>
@@ -1302,5 +1308,107 @@ FFmpeg 輸出 (部分)：
   </data>
   <data name="Warn_LargeMemory" xml:space="preserve">
     <value>將以 {1}×{2}、{3} 幀處理，預估佔用約 {0} MB 記憶體，可能很慢或記憶體不足。要繼續嗎？</value>
+  </data>
+  <data name="Button_RainStatic" xml:space="preserve">
+    <value>下雨特效（圖片）</value>
+  </data>
+  <data name="Button_RainGif" xml:space="preserve">
+    <value>下雨特效（GIF）</value>
+  </data>
+  <data name="Status_RainBuilding" xml:space="preserve">
+    <value>正在產生下雨特效…</value>
+  </data>
+  <data name="RainDialog_Title" xml:space="preserve">
+    <value>下雨特效</value>
+  </data>
+  <data name="RainDialog_RainAmount" xml:space="preserve">
+    <value>雨量</value>
+  </data>
+  <data name="RainDialog_WindDir" xml:space="preserve">
+    <value>風向</value>
+  </data>
+  <data name="RainDialog_WindStrength" xml:space="preserve">
+    <value>風強度</value>
+  </data>
+  <data name="RainDialog_DropLength" xml:space="preserve">
+    <value>雨絲長度</value>
+  </data>
+  <data name="RainDialog_FadeOut" xml:space="preserve">
+    <value>雨停淡出</value>
+  </data>
+  <data name="RainDialog_FadeSeconds" xml:space="preserve">
+    <value>淡出秒數</value>
+  </data>
+  <data name="RainDir_None" xml:space="preserve">
+    <value>無風</value>
+  </data>
+  <data name="RainDir_Left" xml:space="preserve">
+    <value>向左</value>
+  </data>
+  <data name="RainDir_Right" xml:space="preserve">
+    <value>向右</value>
+  </data>
+  <data name="Button_MorphTransition" xml:space="preserve">
+    <value>疊圖轉換 A→B（雨滴暈染／翻轉拼圖）</value>
+  </data>
+  <data name="Status_MorphBuilding" xml:space="preserve">
+    <value>正在產生疊圖轉換…</value>
+  </data>
+  <data name="MorphDialog_Title" xml:space="preserve">
+    <value>疊圖轉換 A → B</value>
+  </data>
+  <data name="MorphDialog_InputA" xml:space="preserve">
+    <value>來源 A（基底）</value>
+  </data>
+  <data name="MorphDialog_InputB" xml:space="preserve">
+    <value>來源 B（顯現）</value>
+  </data>
+  <data name="MorphDialog_Style" xml:space="preserve">
+    <value>樣式</value>
+  </data>
+  <data name="MorphStyle_Raindrop" xml:space="preserve">
+    <value>雨滴暈染</value>
+  </data>
+  <data name="MorphStyle_TileFlip" xml:space="preserve">
+    <value>翻轉拼圖</value>
+  </data>
+  <data name="MorphDialog_PreRoll" xml:space="preserve">
+    <value>先播 A（秒）</value>
+  </data>
+  <data name="MorphDialog_MorphSeconds" xml:space="preserve">
+    <value>轉換（秒）</value>
+  </data>
+  <data name="MorphDialog_RainIntensity" xml:space="preserve">
+    <value>雨滴數</value>
+  </data>
+  <data name="MorphDialog_DropSizeVar" xml:space="preserve">
+    <value>大小變化 %</value>
+  </data>
+  <data name="MorphDialog_SpreadRadius" xml:space="preserve">
+    <value>暈染半徑</value>
+  </data>
+  <data name="MorphDialog_SoftEdge" xml:space="preserve">
+    <value>邊緣柔化</value>
+  </data>
+  <data name="MorphDialog_Divisions" xml:space="preserve">
+    <value>切割格數 (X)</value>
+  </data>
+  <data name="MorphDialog_FlipDir" xml:space="preserve">
+    <value>翻轉方向</value>
+  </data>
+  <data name="FlipDir_Random" xml:space="preserve">
+    <value>隨機</value>
+  </data>
+  <data name="FlipDir_Up" xml:space="preserve">
+    <value>向上</value>
+  </data>
+  <data name="FlipDir_Down" xml:space="preserve">
+    <value>向下</value>
+  </data>
+  <data name="FlipDir_Left" xml:space="preserve">
+    <value>向左</value>
+  </data>
+  <data name="FlipDir_Right" xml:space="preserve">
+    <value>向右</value>
   </data>
 </root>

--- a/SteamGifCropper.Tests/MorphRainRendererTests.cs
+++ b/SteamGifCropper.Tests/MorphRainRendererTests.cs
@@ -1,0 +1,96 @@
+using System;
+using ImageMagick;
+using GifProcessorApp;
+
+namespace SteamGifCropper.Tests;
+
+// Runtime smoke tests for the Magick read/write/crop/resize/composite paths of the rain + morph
+// renderers (the geometry/coverage math is covered by the *FieldTests / *GeometryTests). Each verifies
+// RenderFrame produces a valid same-size image without throwing.
+public class MorphRainRendererTests
+{
+    private static MorphSettings RaindropSettings() => new MorphSettings
+    {
+        Style = MorphStyle.RaindropReveal,
+        Seed = 7,
+        RainIntensity = 12,
+        SpreadRadius = 30,
+        DropSizeVariationPct = 40,
+        SoftEdge = 6,
+    };
+
+    [Fact]
+    public void RainRenderer_PreservesDimensions()
+    {
+        using var src = new MagickImage(MagickColors.SteelBlue, 64, 48);
+        var p = new RainParams { Count = 60, FallSpeed = 200, WindX = 80, StreakLength = 16, Seed = 3 };
+        var streaks = RainField.Streaks(0.5, 64, 48, p);
+        using var outImg = RainRenderer.RenderFrame(src, streaks, 0.8);
+        Assert.Equal(64u, outImg.Width);
+        Assert.Equal(48u, outImg.Height);
+    }
+
+    [Fact]
+    public void RainRenderer_ZeroAlphaOrNoStreaks_DoesNotThrow()
+    {
+        using var src = new MagickImage(MagickColors.SteelBlue, 32, 32);
+        using var a = RainRenderer.RenderFrame(src, new RainStreak[0], 1.0);
+        using var b = RainRenderer.RenderFrame(src, RainField.Streaks(0.0, 32, 32, new RainParams { Count = 10, FallSpeed = 100, StreakLength = 8, Seed = 1 }), 0.0);
+        Assert.Equal(32u, a.Width);
+        Assert.Equal(32u, b.Width);
+    }
+
+    [Fact]
+    public void RaindropRevealRenderer_PreservesDimensions_AcrossProgress()
+    {
+        using var a = new MagickImage(MagickColors.Red, 50, 40);
+        using var b = new MagickImage(MagickColors.Blue, 50, 40);
+        var drops = RaindropRevealField.BuildDrops(RaindropSettings(), 50, 40);
+        foreach (double t in new[] { 0.0, 0.5, 1.0 })
+        {
+            using var outImg = RaindropRevealRenderer.RenderFrame(a, b, t, drops, 6);
+            Assert.Equal(50u, outImg.Width);
+            Assert.Equal(40u, outImg.Height);
+        }
+    }
+
+    [Theory]
+    [InlineData(0.0)]
+    [InlineData(0.5)]
+    [InlineData(1.0)]
+    public void TileFlipRenderer_PreservesDimensions(double t)
+    {
+        using var a = new MagickImage(MagickColors.Red, 80, 50);
+        using var b = new MagickImage(MagickColors.Blue, 80, 50);
+        var settings = new MorphSettings { Style = MorphStyle.TileFlip, Divisions = 6, FlipDirection = TileFlipDirection.Random, Seed = 9 };
+        var grid = TileFlipGeometry.ComputeGrid(80, 50, settings.Divisions);
+        using var outImg = TileFlipRenderer.RenderFrame(a, b, t, grid, settings);
+        Assert.Equal(80u, outImg.Width);
+        Assert.Equal(50u, outImg.Height);
+    }
+
+    [Fact]
+    public void MorphFrame_NextToClonedFrame_OptimizeDoesNotThrow()
+    {
+        // The morph engine mixes rendered morph frames with cloned A/B frames; without uniform page
+        // metadata Optimize() raises "image pages are not coalesced". The renderer ResetPage()s its
+        // output and the engine ResetPage()s the clones — together they must Optimize cleanly.
+        using var a = new MagickImage(MagickColors.Red, 60, 40);
+        using var b = new MagickImage(MagickColors.Blue, 60, 40);
+        var settings = new MorphSettings { Style = MorphStyle.TileFlip, Divisions = 4, Seed = 2 };
+        var grid = TileFlipGeometry.ComputeGrid(60, 40, settings.Divisions);
+        using var coll = new MagickImageCollection();
+
+        var rendered = TileFlipRenderer.RenderFrame(a, b, 0.5, grid, settings);
+        rendered.AnimationDelay = 5;
+        coll.Add(rendered);
+
+        var cloned = (MagickImage)b.Clone();
+        cloned.ResetPage();
+        cloned.AnimationDelay = 5;
+        coll.Add(cloned);
+
+        coll.Optimize(); // must not throw
+        Assert.Equal(2, coll.Count);
+    }
+}

--- a/SteamGifCropper.Tests/MorphTimelineTests.cs
+++ b/SteamGifCropper.Tests/MorphTimelineTests.cs
@@ -1,0 +1,42 @@
+using System;
+using GifProcessorApp;
+
+namespace SteamGifCropper.Tests;
+
+public class MorphTimelineTests
+{
+    [Fact]
+    public void TotalSeconds_WorkedExample()
+    {
+        // A=10s, B=11s, pre-roll 4s, morph 6s -> 4 + 6 + (11-6) = 15s.
+        Assert.Equal(15.0, MorphTimeline.TotalSeconds(4.0, 6.0, 10.0, 11.0), 6);
+    }
+
+    [Fact]
+    public void TotalSeconds_EqualsPreRollPlusBDuration_WhenMorphFits()
+    {
+        Assert.Equal(4.0 + 11.0, MorphTimeline.TotalSeconds(4.0, 6.0, 10.0, 11.0), 6);
+        Assert.Equal(2.0 + 8.0, MorphTimeline.TotalSeconds(2.0, 3.0, 99.0, 8.0), 6);
+    }
+
+    [Fact]
+    public void ClampMorph_NeverExceedsBDuration()
+    {
+        Assert.Equal(11.0, MorphTimeline.ClampMorph(20.0, 11.0), 6);
+        Assert.Equal(6.0, MorphTimeline.ClampMorph(6.0, 11.0), 6);
+        Assert.Equal(0.0, MorphTimeline.ClampMorph(-1.0, 11.0), 6);
+    }
+
+    [Fact]
+    public void TotalSeconds_MorphLongerThanB_ClampsToPreRollPlusB()
+    {
+        // Morph 20s but B is only 3s -> morph clamps to 3, no remaining B -> 4 + 3 = 7.
+        Assert.Equal(7.0, MorphTimeline.TotalSeconds(4.0, 20.0, 10.0, 3.0), 6);
+    }
+
+    [Fact]
+    public void TotalSeconds_NegativePreRollTreatedAsZero()
+    {
+        Assert.Equal(11.0, MorphTimeline.TotalSeconds(-5.0, 6.0, 10.0, 11.0), 6);
+    }
+}

--- a/SteamGifCropper.Tests/RainFieldTests.cs
+++ b/SteamGifCropper.Tests/RainFieldTests.cs
@@ -1,0 +1,73 @@
+using System;
+using GifProcessorApp;
+
+namespace SteamGifCropper.Tests;
+
+public class RainFieldTests
+{
+    [Fact]
+    public void DropCount_ScalesWithAmount_AndClamps()
+    {
+        int low = RainField.DropCount(20, 766, 400);
+        int high = RainField.DropCount(80, 766, 400);
+        Assert.True(high > low);
+        Assert.Equal(0, RainField.DropCount(0, 766, 400));
+        // Negative / over-100 amounts are clamped (no exception, same as 0 / 100).
+        Assert.Equal(RainField.DropCount(0, 766, 400), RainField.DropCount(-50, 766, 400));
+        Assert.Equal(RainField.DropCount(100, 766, 400), RainField.DropCount(150, 766, 400));
+    }
+
+    [Fact]
+    public void Streaks_ReturnsRequestedCount()
+    {
+        var p = new RainParams { Count = 50, FallSpeed = 400, WindX = 0, StreakLength = 20, Seed = 123 };
+        var streaks = RainField.Streaks(0.0, 766, 400, p);
+        Assert.Equal(50, streaks.Length);
+    }
+
+    [Fact]
+    public void Streaks_TailTrailsBehindVelocity()
+    {
+        // Wind to the right + gravity: the tail is up and to the LEFT of the head (X1<X0, Y1<Y0).
+        var right = new RainParams { Count = 40, FallSpeed = 400, WindX = 200, StreakLength = 24, Seed = 7 };
+        foreach (var s in RainField.Streaks(0.0, 766, 400, right))
+        {
+            Assert.True(s.X1 <= s.X0 + 1e-9);
+            Assert.True(s.Y1 <= s.Y0 + 1e-9);
+        }
+
+        // Wind to the left: the tail is to the RIGHT of the head (X1>X0).
+        var left = new RainParams { Count = 40, FallSpeed = 400, WindX = -200, StreakLength = 24, Seed = 7 };
+        foreach (var s in RainField.Streaks(0.0, 766, 400, left))
+        {
+            Assert.True(s.X1 >= s.X0 - 1e-9);
+        }
+    }
+
+    [Fact]
+    public void ToParams_WindDirectionSetsSign()
+    {
+        Assert.True(new RainSettings { WindDirection = RainWindDirection.Left, WindStrength = 150 }.ToParams(766, 400).WindX < 0);
+        Assert.True(new RainSettings { WindDirection = RainWindDirection.Right, WindStrength = 150 }.ToParams(766, 400).WindX > 0);
+        Assert.Equal(0.0, new RainSettings { WindDirection = RainWindDirection.None, WindStrength = 150 }.ToParams(766, 400).WindX, 6);
+    }
+
+    [Fact]
+    public void FadeAlpha_FullInsideWindow_ZeroOutside()
+    {
+        Assert.Equal(1.0, RainField.FadeAlpha(2.0, 6.0, false, 1.0), 6);
+        Assert.Equal(0.0, RainField.FadeAlpha(-0.1, 6.0, false, 1.0), 6);
+        Assert.Equal(0.0, RainField.FadeAlpha(6.1, 6.0, false, 1.0), 6);
+    }
+
+    [Fact]
+    public void FadeAlpha_RampsToZeroOverFadeWindow()
+    {
+        // 6s window, 2s fade-out -> full until t=4, half at t=5, zero at t=6.
+        Assert.Equal(1.0, RainField.FadeAlpha(3.9, 6.0, true, 2.0), 6);
+        Assert.Equal(0.5, RainField.FadeAlpha(5.0, 6.0, true, 2.0), 6);
+        Assert.Equal(0.0, RainField.FadeAlpha(6.0, 6.0, true, 2.0), 6);
+        Assert.False(RainField.AnyRainActive(6.0, 6.0, true, 2.0));
+        Assert.True(RainField.AnyRainActive(3.0, 6.0, true, 2.0));
+    }
+}

--- a/SteamGifCropper.Tests/RaindropRevealFieldTests.cs
+++ b/SteamGifCropper.Tests/RaindropRevealFieldTests.cs
@@ -1,0 +1,50 @@
+using System;
+using GifProcessorApp;
+
+namespace SteamGifCropper.Tests;
+
+public class RaindropRevealFieldTests
+{
+    private static MorphSettings Settings() => new MorphSettings
+    {
+        Seed = 42,
+        RainIntensity = 20,
+        SpreadRadius = 80,
+        DropSizeVariationPct = 40,
+        SoftEdge = 8,
+    };
+
+    [Fact]
+    public void BuildDrops_ReturnsRequestedCount_AndIsDeterministic()
+    {
+        var s = Settings();
+        var a = RaindropRevealField.BuildDrops(s, 300, 200);
+        var b = RaindropRevealField.BuildDrops(s, 300, 200);
+        Assert.Equal(20, a.Length);
+        Assert.Equal(a[0].Px, b[0].Px, 9);
+        Assert.Equal(a[5].MaxR, b[5].MaxR, 9);
+    }
+
+    [Fact]
+    public void Coverage_IsZeroAtStart_AndFullAtEnd()
+    {
+        var drops = RaindropRevealField.BuildDrops(Settings(), 300, 200);
+        Assert.Equal(0.0, RaindropRevealField.Coverage(150, 100, 0.0, drops, 8), 6);
+        // Global floor guarantees a fully-B frame at t=1 everywhere on the canvas.
+        Assert.Equal(1.0, RaindropRevealField.Coverage(10, 10, 1.0, drops, 8), 6);
+        Assert.Equal(1.0, RaindropRevealField.Coverage(299, 199, 1.0, drops, 8), 6);
+    }
+
+    [Fact]
+    public void Coverage_IsMonotonicInTime()
+    {
+        var drops = RaindropRevealField.BuildDrops(Settings(), 300, 200);
+        double prev = -1.0;
+        for (double t = 0.0; t <= 1.0001; t += 0.1)
+        {
+            double c = RaindropRevealField.Coverage(150, 100, t, drops, 8);
+            Assert.True(c >= prev - 1e-9, $"coverage dropped at t={t}: {c} < {prev}");
+            prev = c;
+        }
+    }
+}

--- a/SteamGifCropper.Tests/SteamGifCropper.Tests.csproj
+++ b/SteamGifCropper.Tests/SteamGifCropper.Tests.csproj
@@ -49,6 +49,14 @@
     <Compile Include="..\src\Core\RippleRenderer.cs" Link="RippleRenderer.cs" />
     <Compile Include="..\src\Core\WindField.cs" Link="WindField.cs" />
     <Compile Include="..\src\Core\WindSettings.cs" Link="WindSettings.cs" />
+    <Compile Include="..\src\Core\RainField.cs" Link="RainField.cs" />
+    <Compile Include="..\src\Core\RainSettings.cs" Link="RainSettings.cs" />
+    <Compile Include="..\src\Core\RaindropRevealField.cs" Link="RaindropRevealField.cs" />
+    <Compile Include="..\src\Core\MorphSettings.cs" Link="MorphSettings.cs" />
+    <Compile Include="..\src\Core\TileFlipGeometry.cs" Link="TileFlipGeometry.cs" />
+    <Compile Include="..\src\Core\RainRenderer.cs" Link="RainRenderer.cs" />
+    <Compile Include="..\src\Core\RaindropRevealRenderer.cs" Link="RaindropRevealRenderer.cs" />
+    <Compile Include="..\src\Core\TileFlipRenderer.cs" Link="TileFlipRenderer.cs" />
     <Compile Include="..\src\Core\GridMosaicSettings.cs" Link="GridMosaicSettings.cs" />
     <Compile Include="..\src\Core\GridMosaicRenderer.cs" Link="GridMosaicRenderer.cs" />
     <Compile Include="..\src\Core\GifConcatenationSettings.cs" Link="GifConcatenationSettings.cs" />

--- a/SteamGifCropper.Tests/TileFlipGeometryTests.cs
+++ b/SteamGifCropper.Tests/TileFlipGeometryTests.cs
@@ -1,0 +1,67 @@
+using System;
+using GifProcessorApp;
+
+namespace SteamGifCropper.Tests;
+
+public class TileFlipGeometryTests
+{
+    [Fact]
+    public void ComputeGrid_SquareCanvas_GivesSquareCells()
+    {
+        var g = TileFlipGeometry.ComputeGrid(400, 400, 4);
+        Assert.Equal(4, g.Cols);
+        Assert.Equal(4, g.Rows);
+        Assert.Equal(g.CellW, g.CellH, 6);
+    }
+
+    [Theory]
+    [InlineData(766, 400, 8)]
+    [InlineData(766, 766, 6)]
+    [InlineData(300, 500, 5)]
+    public void ComputeGrid_CellsAreNearSquare(int w, int h, int divisions)
+    {
+        var g = TileFlipGeometry.ComputeGrid(w, h, divisions);
+        Assert.Equal(divisions, g.Cols);
+        Assert.True(g.Rows >= 1);
+        double ratio = g.CellW / g.CellH;
+        // "near square": within a comfortable band given integer row rounding.
+        Assert.InRange(ratio, 0.6, 1.6);
+    }
+
+    [Fact]
+    public void CellScale_FlipsThroughZeroAtMidpoint()
+    {
+        Assert.Equal(1.0, TileFlipGeometry.CellScale(0.0), 6);
+        Assert.Equal(0.0, TileFlipGeometry.CellScale(0.5), 6);
+        Assert.Equal(1.0, TileFlipGeometry.CellScale(1.0), 6);
+    }
+
+    [Fact]
+    public void CellShowsB_OnlyAfterMidpoint()
+    {
+        Assert.False(TileFlipGeometry.CellShowsB(0.0));
+        Assert.False(TileFlipGeometry.CellShowsB(0.49));
+        Assert.True(TileFlipGeometry.CellShowsB(0.5));
+        Assert.True(TileFlipGeometry.CellShowsB(1.0));
+    }
+
+    [Fact]
+    public void CellPhase_AllCellsZeroAtStart_FullAtEnd()
+    {
+        var g = TileFlipGeometry.ComputeGrid(766, 400, 8);
+        for (int i = 0; i < g.Count; i++)
+        {
+            Assert.Equal(0.0, TileFlipGeometry.CellPhase(i, 0.0, 7, 0.35), 6);
+            Assert.Equal(1.0, TileFlipGeometry.CellPhase(i, 1.0, 7, 0.35), 6);
+        }
+    }
+
+    [Fact]
+    public void CellAxis_FollowsDirection()
+    {
+        Assert.Equal(1, TileFlipGeometry.CellAxis(0, TileFlipDirection.Up, 7));
+        Assert.Equal(1, TileFlipGeometry.CellAxis(3, TileFlipDirection.Down, 7));
+        Assert.Equal(0, TileFlipGeometry.CellAxis(0, TileFlipDirection.Left, 7));
+        Assert.Equal(0, TileFlipGeometry.CellAxis(3, TileFlipDirection.Right, 7));
+    }
+}

--- a/docs/CreativeEffectsDevLog.md
+++ b/docs/CreativeEffectsDevLog.md
@@ -194,3 +194,40 @@
   - `MergeAndSplitFiveGifs`：它更重（`collections`→`resizedCollections`→`syncedCollections`→merged `output` 共 ~4 份 clone）。改成 resize 完就釋放 `collections`、sync 完就釋放 `resizedCollections`（最外層 `finally` 仍會再 dispose 一次——`MagickImageCollection.Dispose` 為 idempotent，安全）。
 - **事前警告**：兩條路徑都在動工前用共用的 `ConfirmLargeMemory(mainForm, estMb, w, h, frames)`（從 `ConfirmLargeCanvas` 抽出）估算（合併=Σ來源像素＋結果像素；合併並切 5≈來源×2 的 clone 重疊），超門檻跳 Yes/No、取消則提前 return（外層 finally 照樣 dispose／還原 0x21）。`ConfirmLargeMemory` 改用 `InvokeRequired` 判斷，UI thread 直接跑、背景 thread 才 marshal（合併的呼叫點在 UI thread）。
 - **結論**：合併不會再失控吃到 24–40GB；最壞是走磁碟變慢或丟可攔截的錯誤。前提仍是 temp 磁碟要有 ~8GB 空間。
+
+---
+
+## 下雨疊層特效（Rain Overlay）— 已實作
+
+在圖片／GIF 上**疊一層半透明雨絲**（注意：是 overlay 合成，**非**像素位移；與 ripple/wind 的折射不同）。比照 wind 的整體骨架（入口/Run/分派/play-along/frozen-then-play、`GifEffectWindow` 時間窗、inline dialog + theme、純函式抽出單測、三語 resx、輸出單一 766px 全寬可串接）。
+
+- **渲染慣例**：repo 刻意不用 Magick `Drawables`（XC 政策 + Q8 量化），故 `RainRenderer` 直接把雨絲以 **DDA 畫線 + alpha-blend 寫進 RGBA `byte[]`**（同 ripple/wind 的 buffer 寫法），非 Drawables。雨色淺藍白、stroke alpha 0.55 × 層淡出。
+- **數學模型**（`RainField.cs`，純函式）：`DropCount(amount,w,h)` 由 0..100 雨量 × 畫布面積換算（夾 40..1500）；每滴用**種子化 hash**（`Hash01(i,salt,seed)`，無 RNG 狀態 → 純函式可重現）取 x/相位/速度因子/長度因子；`Streaks(t,w,h,p)` 回傳線段陣列（head→tail，tail 沿速度反向 = motion-blur），head 在畫布 + 40px 上緣 margin 內**垂直/水平 wrap**（連續且循環）；風向/風強度給橫向 drift → 雨絲傾斜。`FadeAlpha(te,winDur,fadeOut,fadeSeconds)`＝雨停在窗尾 `fadeSeconds` 內 1→0 線性淡出；`AnyRainActive` 讓無雨幀直接複製。
+- **設定**（`RainSettings.cs`，`ToParams(w,h)` 把尺寸無關值解析成 `RainParams`）：`RainAmount`(0..100)、`WindDirection`(None/Left/Right enum→index)、`WindStrength`(px/s)、`DropLength`、`FadeOut`+`FadeOutSeconds`、`Seed`，＋場景 `Fps/DurationSeconds/EffectStartSeconds/PlayGifDuringRain/KeepOriginalSize`。
+- **播放**：`BuildRainPlayAlong`（雨混在 `[EffectStart,+Duration)` 窗內的 live 幀、窗外播原片、**輸出=GIF 全長**；雨絲用**絕對時間** `startSec[i]` 連續移動、淡出用窗內**相對時間** `te`）／`BuildRainFrozenThenPlay`（定格 frame 0 下雨 `Duration` 秒 @ FPS、再播完整 GIF；靜態圖只下雨 `Duration`）。
+- **檔案**：`src/Core/RainField.cs`/`RainSettings.cs`/`RainRenderer.cs`/`GifProcessor.Rain.cs`、`src/Dialogs/RainDialog.cs`（鏡射 `WindDialog`：`MakeNum`/`UpdateUIText`/`ApplyTheme`/dark-light、`BuildSettings(bool)`、`chkFadeOut`→`numFadeSeconds` enable）、主視窗 `btnRainStatic`/`btnRainGif`、`RainFieldTests`（6 例）。
+
+## 疊圖轉換 A→B（Morph Transition）— 已實作
+
+兩個 clip 的轉場，採**全新時間模型**（與既有 concat 的 overlap 模型不同，故獨立 dialog + 單顆按鈕，使用者已同意「另開 topic」）：A 先播 `PreRoll` 秒 → A 在 `Morph` 秒內轉成 B（**轉換結束時 A 已全透明消失、剩餘 A 不播**）→ 播 B 剩餘片段到結束。
+
+- **時間軸恆等式**：`total = PreRoll + Morph + (Bdur − Morph) = PreRoll + Bdur`（當 `Morph ≤ Bdur`；否則 `Morph` 夾到 `Bdur`、無剩餘 B）。例 A=10s/B=11s/PreRoll=4/Morph=6 → 4+6+5 = **15s**。純函式 `MorphTimeline.ClampMorph/TotalSeconds`（在 `MorphSettings.cs`）可單測。
+- **兩風格**（同一 dialog 的 `cmbStyle` 切換兩組控制項，比照 wind 的 Normal/Nuclear）：
+  - **雨滴暈染**（`RaindropRevealField`/`RaindropRevealRenderer`）：種子化雨滴（birth∈[0,0.85)、隨機位置、`MaxR=SpreadRadius×(1±SizeVar%)`）；`Coverage(x,y,t)∈[0,1]`＝各 born 雨滴 `SmoothStep(age)` 成長的 **soft disc union**（soft edge 即「暈開」羽化），疊上 `GlobalFloor(t)`（最後 15% ramp→1，**保證 t=1 全為 B**），對固定像素**單調遞增**。Renderer 逐像素 cross-dissolve `out = A·(1−cov) + B·cov`（`Parallel.For`、RGBA byte[]）。
+  - **翻轉拼圖**（`TileFlipGeometry`/`TileFlipRenderer`）：`ComputeGrid(w,h,divisions)`＝cols=divisions、**rows 自動算成近正方格**；`CellPhase(index,t,seed,flipFraction=0.35)` 用種子 scatter 錯開每格起翻時間（t=1 時全部=1 → 全翻成 B）；`CellScale(phase)=|1−2·phase|`（phase 0.5 時壓成邊緣 sliver）；`CellShowsB(phase)=phase≥0.5`；`CellAxis`（Up/Down 垂直壓、Left/Right 水平壓、Random 種子選軸）。Renderer 逐格 `Crop→ResetPage→Resize(IgnoreAspectRatio 壓扁)→置中 Composite`。
+- **引擎**（`GifProcessor.Morph.cs`）：載入 A/B `Coalesce`；target = A 尺寸（KeepOriginalSize）或 fit 766px 寬；B 各幀以 `FitToCanvas`（保留 aspect、置中、**沿用來源 delay/ticks**）對齊 target，使 morph 能逐像素混合；用 `FrameStartSeconds` 累積秒數 + `GifEffectWindow.NearestFrameIndex` 在 morph 窗內依時間取 A/B 幀（`tA=PreRoll+k/fps` 超過 A 尾自動**凍結最後幀**、`tB=k/fps`）；三段組裝（pre-roll A 原生時序 → N=`round(Morph×fps)` 個 morph 幀 @ delay=`round(100/fps)` → 剩餘 B 原生時序）。
+- **設定**（`MorphSettings.cs`）：`Style`、`PreRollSeconds`、`MorphSeconds`、`Fps`、`KeepOriginalSize`、`Seed`；雨滴組 `RainIntensity/DropSizeVariationPct/SpreadRadius/SoftEdge`（`SpreadVariationPct` 保留未用）；翻轉組 `Divisions/FlipDirection`。
+- **檔案**：`src/Core/MorphSettings.cs`(含 `MorphTimeline`)/`RaindropRevealField.cs`/`RaindropRevealRenderer.cs`/`TileFlipGeometry.cs`/`TileFlipRenderer.cs`/`GifProcessor.Morph.cs`、`src/Dialogs/MorphTransitionDialog.cs`（A/B 兩個輸入 + 輸出、`cmbStyle` 切換 `_raindropControls`/`_tileControls`）、主視窗 `btnMorphTransition`（單顆、整寬）、`RaindropRevealFieldTests`(3)/`TileFlipGeometryTests`(8)/`MorphTimelineTests`(5)。
+
+#### 主視窗版面（rain + morph 一起）
+- `btnRainStatic`/`btnRainGif`（第 12 列 y=348、TabIndex 27/28）、`btnMorphTransition`（第 13 列 y=379、整寬 606、TabIndex 29）。
+- 下方既有元件統一 **+62px**：語言鈕 349→411、資源標籤 351→413、framerate 列 375→437 / 377→439、gifsicle 面板 400→462、status 519→581、進度條 534→596；`ClientSize` 618→**680**。
+- 在地化新增 **34** 鍵（三語 resx + `Resources.Designer.cs`）：`Button_Rain*`/`Status_RainBuilding`/`RainDialog_*`/`RainDir_*`、`Button_MorphTransition`/`Status_MorphBuilding`/`MorphDialog_*`/`MorphStyle_*`/`FlipDir_*`。`csproj` test 連結新增 5 個純檔（`RainField`/`RainSettings`/`RaindropRevealField`/`MorphSettings`/`TileFlipGeometry`）。全 **214** 例綠燈、build 0 warning。
+
+## SIMD 加速評估（本輪：維持 Parallel.For，延後）
+
+決策：本輪**不**做向量化（使用者選「先用 Parallel.For，SIMD 之後再評估」）。
+
+- **熱點候選**（raw RGBA `byte[]`、SIMD 友善）：`RippleRenderer`/`WindRenderer.SampleBilinearRgba`（4-channel 雙線性權重）、`RaindropRevealRenderer` 的逐像素 cross-dissolve。
+- **效益低、不值得**：Rain 雨絲（稀疏 DDA 畫線、非密集像素迴圈）、TileFlip（瓶頸在 Magick `Crop/Resize/Composite`，非自寫迴圈）。
+- **日後若要動手**：`SteamGifCropper.csproj` 加 `<AllowUnsafeBlocks>true</AllowUnsafeBlocks>`，用 `System.Numerics.Vector<T>` 或 `System.Runtime.Intrinsics`（Vector256/Avx2）；**先用 `Stopwatch` benchmark** 確認時間真的花在像素迴圈（而非 ImageMagick 內部 `Composite`，那本身可能已向量化），再決定向量化哪個 kernel。現有 `Parallel.For` 已跨 row 平行，先確保正確性。

--- a/docs/CreativeFeatureIdeas.md
+++ b/docs/CreativeFeatureIdeas.md
@@ -22,6 +22,9 @@
 - ✅ **合併 2–5 GIF：來源檔尾 0x21 自動處理** — 載入前自動把 Steam 檔尾 0x21 翻回 0x3B、處理後還原，並回報中途動到/無法還原的檔。
 - ✅ **微/強風吹襲（Wind Sway，風吹麥田）** — 沿風向掃過畫面的行進波 + 陣風時間漲落（Hann 包絡），視覺如風吹過麥田起伏；水波紋的方向版（平面波取代徑向波，渲染管線獨立複本）。共用 8 方向風向 + 總時間；每陣風（最多 3）各有起始/時長/強度。核爆版（dialog 模式切換、單一事件）先正向短吹→靜止→反向強風持續。GIF 同步混合（影片 15s/風 6s → 前 6s mixing + 後 9s 原片）或定格再播。
 - ✅ **通用尺寸開關（保持原始尺寸 / 不縮到 766px）** — 水波紋/風/流沙底層 math 本就尺寸無關，加 per-dialog 勾選框把它們當通用 GIF 特效用（非 Steam 前置）；大檔先估記憶體、超門檻跳警告可取消。拉霸/格網維持 766-only（語意是 5 槽位）。
+- ✅ **下雨疊層特效（Rain Overlay）** — 在 GIF 上疊一層半透明雨絲（overlay 合成，非位移）：雨量、風強度、風向、開始秒數、長度、雨停 fade-out + 淡出秒數；比照 wind 的 play-along / frozen-then-play 與時間窗。雨絲用種子化 hash + 畫布 wrap、DDA 畫線 alpha-blend 寫進 RGBA buffer（沿 repo 不用 Drawables 慣例）。
+- ✅ **疊圖轉換 A→B（Morph Transition）** — 兩 clip 全新時間模型（先播 A → A 在窗內轉成 B、A 結束全透明消失 → 播 B 剩餘；總長 = PreRoll + Bdur）。兩風格同一 dialog 切換：**雨滴暈染**（種子化雨滴 soft-disc coverage cross-dissolve A→B、GlobalFloor 保證收尾全 B）與**翻轉拼圖**（近正方格、種子錯開逐格 squash 翻面 A→B、方向隨機/固定）。math 抽純函式單測（`RaindropRevealField`/`TileFlipGeometry`/`MorphTimeline`）。
+- ✅ **SIMD 評估（延後）** — 維持 `Parallel.For`；熱點（bilinear 取樣、raindrop cross-dissolve）與動手條件（`AllowUnsafeBlocks` + `System.Numerics.Vector`/`Intrinsics`、先 benchmark）記於 dev log。
 
 ---
 

--- a/src/Core/GifProcessor.Morph.cs
+++ b/src/Core/GifProcessor.Morph.cs
@@ -1,0 +1,252 @@
+using ImageMagick;
+using SteamGifCropper;
+using SteamGifCropper.Properties;
+using System;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+
+namespace GifProcessorApp
+{
+    public static partial class GifProcessor
+    {
+        #region A->B Morph Transition (疊圖轉換) Methods
+
+        // Morph one clip into another: A plays for PreRoll seconds, then A morphs into B over MorphSeconds
+        // (A is fully gone by the end and its leftover is discarded), then B's remaining footage plays to
+        // the end. Two morph styles: raindrop-spread reveal and tile-flip. Output is a single full-width
+        // 766px GIF (no auto-split), chainable; split with the main "Split GIF" button.
+        public static async Task MorphTransition(GifToolMainForm mainForm)
+        {
+            using var dialog = new MorphTransitionDialog();
+            if (dialog.ShowDialog(mainForm) != DialogResult.OK)
+            {
+                return;
+            }
+            await RunMorph(mainForm, dialog.BuildSettings());
+        }
+
+        private static async Task RunMorph(GifToolMainForm mainForm, MorphSettings settings)
+        {
+            mainForm.Enabled = false;
+            SetProgressRange(mainForm, 0, 100);
+            SetProgressBar(mainForm.pBarTaskStatus, 0, 100);
+            SetProgressVisible(mainForm, true);
+
+            bool canceled = false;
+            try
+            {
+                await Task.Run(() =>
+                {
+                    SetStatusText(mainForm, SteamGifCropper.Properties.Resources.Status_MorphBuilding);
+
+                    using var aSrc = new MagickImageCollection(settings.InputAPath);
+                    aSrc.Coalesce();
+                    using var bSrc = new MagickImageCollection(settings.InputBPath);
+                    bSrc.Coalesce();
+
+                    // Target canvas: A's size, or fit A to 766px wide when its width isn't a supported one.
+                    uint aw = aSrc[0].Width;
+                    uint ah = aSrc[0].Height;
+                    if (!settings.KeepOriginalSize && !IsValidCanvasWidth(aw))
+                    {
+                        foreach (var frame in aSrc)
+                        {
+                            frame.ResetPage();
+                            frame.Resize(SupportedWidth1, 0);
+                        }
+                        aw = aSrc[0].Width;
+                        ah = aSrc[0].Height;
+                    }
+                    int targetW = (int)aw;
+                    int targetH = (int)ah;
+
+                    // Fit B onto the same canvas (preserve aspect, centre) so the morph blends pixel-for-pixel.
+                    using var bFit = new MagickImageCollection();
+                    foreach (var frame in bSrc)
+                    {
+                        bFit.Add(FitToCanvas(frame, targetW, targetH));
+                    }
+
+                    // Per-frame start times + total length for A and B.
+                    int aTicks = (int)aSrc[0].AnimationTicksPerSecond; if (aTicks <= 0) aTicks = 100;
+                    int bTicks = (int)bSrc[0].AnimationTicksPerSecond; if (bTicks <= 0) bTicks = 100;
+                    double[] aStart = FrameStartSeconds(aSrc, aTicks, out double aDur);
+                    double[] bStart = FrameStartSeconds(bSrc, bTicks, out double bDur);
+
+                    double morph = MorphTimeline.ClampMorph(settings.MorphSeconds, bDur);
+                    double preRoll = settings.PreRollSeconds < 0.0 ? 0.0 : settings.PreRollSeconds;
+
+                    int estFrames = EstimateMorphFrames(aStart, bStart, preRoll, morph, settings.Fps);
+                    if (!ConfirmLargeCanvas(mainForm, estFrames, (uint)targetW, (uint)targetH))
+                    {
+                        canceled = true;
+                        return;
+                    }
+
+                    using var animation = BuildMorph(mainForm, aSrc, bFit, aStart, bStart, aDur, bDur,
+                        aTicks, bTicks, targetW, targetH, preRoll, morph, settings, estFrames);
+                    SetStatusText(mainForm, SteamGifCropper.Properties.Resources.Status_Saving);
+                    animation.Optimize();
+                    animation.Write(settings.OutputPath);
+                });
+
+                if (!canceled)
+                {
+                    SetProgressBar(mainForm.pBarTaskStatus, 100, 100);
+                    SetStatusText(mainForm, SteamGifCropper.Properties.Resources.Status_Done);
+                    WindowsThemeManager.ShowThemeAwareMessageBox(mainForm,
+                        SteamGifCropper.Properties.Resources.Message_ProcessingComplete,
+                        SteamGifCropper.Properties.Resources.Title_Success,
+                        MessageBoxButtons.OK, MessageBoxIcon.Information);
+                }
+            }
+            catch (Exception ex)
+            {
+                SetStatusText(mainForm, SteamGifCropper.Properties.Resources.Status_Error);
+                WindowsThemeManager.ShowThemeAwareMessageBox(mainForm,
+                    string.Format(SteamGifCropper.Properties.Resources.Error_Occurred, ex.Message),
+                    SteamGifCropper.Properties.Resources.Title_Error,
+                    MessageBoxButtons.OK, MessageBoxIcon.Error);
+            }
+            finally
+            {
+                mainForm.Enabled = true;
+                SetProgressBar(mainForm.pBarTaskStatus, 0, 100);
+                SetStatusText(mainForm, SteamGifCropper.Properties.Resources.Status_Idle);
+            }
+        }
+
+        // Cumulative native start time (seconds) of each frame; out total clip length.
+        private static double[] FrameStartSeconds(MagickImageCollection col, int ticks, out double totalSeconds)
+        {
+            int n = col.Count;
+            double[] startSec = new double[n];
+            double acc = 0.0;
+            for (int i = 0; i < n; i++)
+            {
+                startSec[i] = acc;
+                acc += (double)col[i].AnimationDelay / ticks;
+            }
+            totalSeconds = acc;
+            return startSec;
+        }
+
+        // preRoll frames of A + N morph frames + remaining frames of B.
+        private static int EstimateMorphFrames(double[] aStart, double[] bStart, double preRoll, double morph, int fps)
+        {
+            int pre = 0;
+            for (int i = 0; i < aStart.Length; i++) if (aStart[i] < preRoll) pre++;
+            int n = Math.Max(1, (int)Math.Round(morph * Math.Max(1, fps)));
+            int rem = 0;
+            for (int i = 0; i < bStart.Length; i++) if (bStart[i] >= morph) rem++;
+            return pre + n + rem;
+        }
+
+        // Scale `src` to fit a targetW x targetH canvas (preserve aspect), centred on transparent, with the
+        // source frame's timing carried over. Returns a new image exactly targetW x targetH.
+        private static MagickImage FitToCanvas(IMagickImage<byte> src, int targetW, int targetH)
+        {
+            var scaled = (MagickImage)src.Clone();
+            scaled.ResetPage();
+            if ((int)scaled.Width != targetW || (int)scaled.Height != targetH)
+            {
+                scaled.Resize(new MagickGeometry((uint)targetW, (uint)targetH) { IgnoreAspectRatio = false });
+            }
+            if ((int)scaled.Width == targetW && (int)scaled.Height == targetH)
+            {
+                scaled.AnimationDelay = src.AnimationDelay;
+                scaled.AnimationTicksPerSecond = src.AnimationTicksPerSecond;
+                return scaled;
+            }
+
+            var canvas = new MagickImage(MagickColors.Transparent, (uint)targetW, (uint)targetH);
+            int x = (targetW - (int)scaled.Width) / 2;
+            int y = (targetH - (int)scaled.Height) / 2;
+            canvas.Composite(scaled, x, y, CompositeOperator.Over);
+            canvas.ResetPage();
+            canvas.AnimationDelay = src.AnimationDelay;
+            canvas.AnimationTicksPerSecond = src.AnimationTicksPerSecond;
+            scaled.Dispose();
+            return canvas;
+        }
+
+        private static MagickImageCollection BuildMorph(GifToolMainForm mainForm,
+            MagickImageCollection aSrc, MagickImageCollection bFit,
+            double[] aStart, double[] bStart, double aDur, double bDur, int aTicks, int bTicks,
+            int targetW, int targetH, double preRoll, double morph, MorphSettings settings, int totalFrames)
+        {
+            int fps = Math.Max(1, settings.Fps);
+            int delay = Math.Max(1, (int)Math.Round(100.0 / fps));
+
+            RaindropSeed[] drops = settings.Style == MorphStyle.RaindropReveal
+                ? RaindropRevealField.BuildDrops(settings, targetW, targetH)
+                : null;
+            TileGrid grid = settings.Style == MorphStyle.TileFlip
+                ? TileFlipGeometry.ComputeGrid(targetW, targetH, settings.Divisions)
+                : default;
+
+            var result = new MagickImageCollection();
+            int built = 0;
+
+            // Phase 1: A alone for the pre-roll, at A's native timing.
+            for (int i = 0; i < aSrc.Count; i++)
+            {
+                if (aStart[i] >= preRoll) break;
+                var frame = (MagickImage)aSrc[i].Clone();
+                frame.ResetPage();
+                frame.AnimationDelay = aSrc[i].AnimationDelay;
+                frame.AnimationTicksPerSecond = aTicks;
+                frame.GifDisposeMethod = GifDisposeMethod.Background;
+                result.Add(frame);
+                ReportMorph(mainForm, ++built, totalFrames);
+            }
+
+            // Phase 2: the morph window (A and B both advance; A is fully gone by t=1).
+            int n = Math.Max(1, (int)Math.Round(morph * fps));
+            for (int k = 0; k < n; k++)
+            {
+                double tA = preRoll + (double)k / fps;
+                int idxA = GifEffectWindow.NearestFrameIndex(aStart, Math.Min(tA, Math.Max(0.0, aDur)));
+                double tB = (double)k / fps;
+                int idxB = GifEffectWindow.NearestFrameIndex(bStart, tB);
+                double t = n == 1 ? 1.0 : (double)k / (n - 1);
+
+                MagickImage frame = settings.Style == MorphStyle.RaindropReveal
+                    ? RaindropRevealRenderer.RenderFrame(aSrc[idxA], bFit[idxB], t, drops, settings.SoftEdge)
+                    : TileFlipRenderer.RenderFrame(aSrc[idxA], bFit[idxB], t, grid, settings);
+                frame.AnimationDelay = (uint)delay;
+                frame.AnimationTicksPerSecond = 100;
+                frame.GifDisposeMethod = GifDisposeMethod.Background;
+                result.Add(frame);
+                ReportMorph(mainForm, ++built, totalFrames);
+            }
+
+            // Phase 3: B's remaining footage, at B's native timing.
+            for (int i = 0; i < bFit.Count; i++)
+            {
+                if (bStart[i] < morph) continue;
+                var frame = (MagickImage)bFit[i].Clone();
+                frame.ResetPage();
+                frame.AnimationDelay = bFit[i].AnimationDelay;
+                frame.AnimationTicksPerSecond = bTicks;
+                frame.GifDisposeMethod = GifDisposeMethod.Background;
+                result.Add(frame);
+                ReportMorph(mainForm, ++built, totalFrames);
+            }
+
+            return result;
+        }
+
+        private static void ReportMorph(GifToolMainForm mainForm, int built, int total)
+        {
+            if (total <= 0) total = 1;
+            if (built % 5 == 0 || built == total)
+            {
+                SetProgressBar(mainForm.pBarTaskStatus, built * 100 / total, 100);
+                SetStatusText(mainForm, SteamGifCropper.Properties.Resources.Status_MorphBuilding);
+            }
+        }
+
+        #endregion
+    }
+}

--- a/src/Core/GifProcessor.Rain.cs
+++ b/src/Core/GifProcessor.Rain.cs
@@ -1,0 +1,248 @@
+using ImageMagick;
+using SteamGifCropper;
+using SteamGifCropper.Properties;
+using System;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+
+namespace GifProcessorApp
+{
+    public static partial class GifProcessor
+    {
+        #region Rain Overlay (下雨) Methods
+
+        // Overlay a translucent rain layer (slanted streaks, optional wind + a "rain stops" fade-out) on
+        // an image / GIF. Output is a single full-width 766px GIF (no auto-split), chainable; split with
+        // the main "Split GIF" button.
+        public static async Task RainStaticImage(GifToolMainForm mainForm)
+        {
+            using var dialog = new RainDialog(false);
+            if (dialog.ShowDialog(mainForm) != DialogResult.OK)
+            {
+                return;
+            }
+            await RunRain(mainForm, dialog.BuildSettings(false));
+        }
+
+        public static async Task RainGif(GifToolMainForm mainForm)
+        {
+            using var dialog = new RainDialog(true);
+            if (dialog.ShowDialog(mainForm) != DialogResult.OK)
+            {
+                return;
+            }
+            await RunRain(mainForm, dialog.BuildSettings(true));
+        }
+
+        private static async Task RunRain(GifToolMainForm mainForm, RainSettings settings)
+        {
+            mainForm.Enabled = false;
+            SetProgressRange(mainForm, 0, 100);
+            SetProgressBar(mainForm.pBarTaskStatus, 0, 100);
+            SetProgressVisible(mainForm, true);
+
+            bool canceled = false;
+            try
+            {
+                await Task.Run(() =>
+                {
+                    SetStatusText(mainForm, SteamGifCropper.Properties.Resources.Status_RainBuilding);
+                    using var source = new MagickImageCollection(settings.InputFilePath);
+                    source.Coalesce();
+
+                    // Auto-resize to 766px wide when not already a supported width (rain density scales to
+                    // this canvas) — unless the user opted to keep the original size.
+                    uint width = source[0].Width;
+                    if (!settings.KeepOriginalSize && !IsValidCanvasWidth(width))
+                    {
+                        foreach (var frame in source)
+                        {
+                            frame.ResetPage();
+                            frame.Resize(SupportedWidth1, 0);
+                        }
+                        width = source[0].Width;
+                    }
+
+                    // Warn before running at a large native size (rain-over-playback keeps the GIF length;
+                    // frozen / static add the rain frames).
+                    int outFrames = (settings.IsGif && settings.PlayGifDuringRain)
+                        ? source.Count
+                        : (int)Math.Round(Math.Max(0.1, settings.DurationSeconds) * Math.Max(1, settings.Fps)) + (settings.IsGif ? source.Count : 0);
+                    if (!ConfirmLargeCanvas(mainForm, Math.Max(source.Count, outFrames), width, source[0].Height))
+                    {
+                        canceled = true;
+                        return;
+                    }
+
+                    using var animation = BuildRainAnimation(mainForm, source, settings);
+                    SetStatusText(mainForm, SteamGifCropper.Properties.Resources.Status_Saving);
+                    animation.Optimize();
+                    animation.Write(settings.OutputFilePath);
+                });
+
+                if (!canceled)
+                {
+                    SetProgressBar(mainForm.pBarTaskStatus, 100, 100);
+                    SetStatusText(mainForm, SteamGifCropper.Properties.Resources.Status_Done);
+                    WindowsThemeManager.ShowThemeAwareMessageBox(mainForm,
+                        SteamGifCropper.Properties.Resources.Message_ProcessingComplete,
+                        SteamGifCropper.Properties.Resources.Title_Success,
+                        MessageBoxButtons.OK, MessageBoxIcon.Information);
+                }
+            }
+            catch (Exception ex)
+            {
+                SetStatusText(mainForm, SteamGifCropper.Properties.Resources.Status_Error);
+                WindowsThemeManager.ShowThemeAwareMessageBox(mainForm,
+                    string.Format(SteamGifCropper.Properties.Resources.Error_Occurred, ex.Message),
+                    SteamGifCropper.Properties.Resources.Title_Error,
+                    MessageBoxButtons.OK, MessageBoxIcon.Error);
+            }
+            finally
+            {
+                mainForm.Enabled = true;
+                SetProgressBar(mainForm.pBarTaskStatus, 0, 100);
+                SetStatusText(mainForm, SteamGifCropper.Properties.Resources.Status_Idle);
+            }
+        }
+
+        // Dispatcher. GIF + "rain over playback": the GIF keeps playing its full length while the rain is
+        // overlaid on the chosen [start, duration] window. Otherwise (static image, or GIF + "freeze on
+        // frame 0"): rain over a single frozen frame, optionally followed by the full GIF.
+        private static MagickImageCollection BuildRainAnimation(GifToolMainForm mainForm,
+            MagickImageCollection source, RainSettings settings)
+        {
+            int srcTicks = (int)source[0].AnimationTicksPerSecond;
+            if (srcTicks <= 0) srcTicks = 100;
+            int w = (int)source[0].Width;
+            int h = (int)source[0].Height;
+            RainParams rain = settings.ToParams(w, h);
+
+            if (settings.IsGif && settings.PlayGifDuringRain)
+            {
+                return BuildRainPlayAlong(mainForm, source, settings, rain, srcTicks);
+            }
+
+            return BuildRainFrozenThenPlay(mainForm, source, settings, rain, srcTicks);
+        }
+
+        // Output length == source GIF length, native frame timing preserved. Rain is drawn onto each live
+        // frame whose native time falls in the [EffectStart, +Duration) window; frames outside the window
+        // pass through as the plain GIF. The streaks move with absolute time, so the rain is continuous;
+        // the optional fade-out empties the rain over the last FadeOutSeconds of the window.
+        private static MagickImageCollection BuildRainPlayAlong(GifToolMainForm mainForm,
+            MagickImageCollection source, RainSettings settings, RainParams rain, int srcTicks)
+        {
+            int n = source.Count;
+            double duration = settings.DurationSeconds;
+            if (duration < 0.1) duration = 0.1;
+            int w = (int)source[0].Width;
+            int h = (int)source[0].Height;
+
+            double[] startSec = new double[n];
+            double acc = 0.0;
+            for (int i = 0; i < n; i++)
+            {
+                startSec[i] = acc;
+                acc += (double)source[i].AnimationDelay / srcTicks;
+            }
+            double gifSeconds = acc;
+
+            var (winStart, winDur) = GifEffectWindow.Clamp(settings.EffectStartSeconds, duration, gifSeconds);
+
+            var result = new MagickImageCollection();
+            int built = 0;
+            for (int i = 0; i < n; i++)
+            {
+                double te = startSec[i] - winStart; // time within the effect window
+                MagickImage frame;
+                if (te >= 0.0 && te < winDur && RainField.AnyRainActive(te, winDur, settings.FadeOut, settings.FadeOutSeconds))
+                {
+                    double alpha = RainField.FadeAlpha(te, winDur, settings.FadeOut, settings.FadeOutSeconds);
+                    RainStreak[] streaks = RainField.Streaks(startSec[i], w, h, rain);
+                    frame = RainRenderer.RenderFrame(source[i], streaks, alpha);
+                }
+                else
+                {
+                    frame = (MagickImage)source[i].Clone();
+                }
+                frame.ResetPage();
+                frame.AnimationDelay = source[i].AnimationDelay;
+                frame.AnimationTicksPerSecond = srcTicks;
+                frame.GifDisposeMethod = GifDisposeMethod.Background;
+                result.Add(frame);
+
+                if (++built % 5 == 0 || built == n)
+                {
+                    SetProgressBar(mainForm.pBarTaskStatus, built * 100 / n, 100);
+                    SetStatusText(mainForm, SteamGifCropper.Properties.Resources.Status_RainBuilding);
+                }
+            }
+
+            return result;
+        }
+
+        // Rain over a frozen frame 0 (or the static image) for `Duration` seconds at the chosen FPS. For a
+        // GIF this is followed by the full source GIF played at its native timing (output length ==
+        // Duration + GIF length); for a static image there is no play phase (output length == Duration).
+        private static MagickImageCollection BuildRainFrozenThenPlay(GifToolMainForm mainForm,
+            MagickImageCollection source, RainSettings settings, RainParams rain, int srcTicks)
+        {
+            int fps = Math.Max(1, settings.Fps);
+            int delay = Math.Max(1, (int)Math.Round(100.0 / fps));
+
+            double duration = settings.DurationSeconds;
+            if (duration < 0.1) duration = 0.1;
+            int rainFrames = Math.Max(1, (int)Math.Round(duration * fps));
+            int playFrames = settings.IsGif ? source.Count : 0;
+            int totalFrames = rainFrames + playFrames;
+            int w = (int)source[0].Width;
+            int h = (int)source[0].Height;
+
+            var result = new MagickImageCollection();
+            int built = 0;
+
+            // Phase 1: rain over the frozen first frame.
+            for (int f = 0; f < rainFrames; f++)
+            {
+                double t = (double)f / fps;
+                double alpha = RainField.FadeAlpha(t, duration, settings.FadeOut, settings.FadeOutSeconds);
+                RainStreak[] streaks = RainField.Streaks(t, w, h, rain);
+                var frame = RainRenderer.RenderFrame(source[0], streaks, alpha);
+                frame.AnimationDelay = (uint)delay;
+                frame.AnimationTicksPerSecond = 100;
+                frame.GifDisposeMethod = GifDisposeMethod.Background;
+                result.Add(frame);
+
+                if (++built % 5 == 0 || built == totalFrames)
+                {
+                    SetProgressBar(mainForm.pBarTaskStatus, built * 100 / totalFrames, 100);
+                    SetStatusText(mainForm, SteamGifCropper.Properties.Resources.Status_RainBuilding);
+                }
+            }
+
+            // Phase 2 (GIF only): play the full source GIF at native timing after the rain frames.
+            if (settings.IsGif)
+            {
+                foreach (var srcFrame in source)
+                {
+                    var play = (MagickImage)srcFrame.Clone();
+                    play.ResetPage();
+                    play.AnimationTicksPerSecond = srcTicks;
+                    play.GifDisposeMethod = GifDisposeMethod.Background;
+                    result.Add(play);
+
+                    if (++built % 5 == 0 || built == totalFrames)
+                    {
+                        SetProgressBar(mainForm.pBarTaskStatus, built * 100 / totalFrames, 100);
+                        SetStatusText(mainForm, SteamGifCropper.Properties.Resources.Status_RainBuilding);
+                    }
+                }
+            }
+
+            return result;
+        }
+
+        #endregion
+    }
+}

--- a/src/Core/MorphSettings.cs
+++ b/src/Core/MorphSettings.cs
@@ -1,0 +1,75 @@
+using System;
+
+namespace GifProcessorApp
+{
+    // Which A->B morph to run during the transition window.
+    public enum MorphStyle
+    {
+        RaindropReveal = 0, // raindrops fall on A; their spreading puddles cross-dissolve to B
+        TileFlip = 1,       // the canvas is split into cells that flip A->B one by one
+    }
+
+    // Tile-flip squash axis / sense. Up/Down squash vertically, Left/Right horizontally; Random picks a
+    // per-cell axis. Enum order matches the dialog's direction dropdown index.
+    public enum TileFlipDirection
+    {
+        Random = 0,
+        Up = 1,
+        Down = 2,
+        Left = 3,
+        Right = 4,
+    }
+
+    // Parameters for the A->B "morph" transition (its own timeline, distinct from the concat overlap
+    // model): A plays for PreRollSeconds, then A morphs into B over MorphSeconds (A is fully gone by the
+    // end and its leftover is discarded), then B's remaining footage plays to the end. Output is a single
+    // full-width 766px GIF (no auto-split), chainable. BuildSettings() does the control->settings mapping.
+    public class MorphSettings
+    {
+        public string InputAPath { get; set; }
+        public string InputBPath { get; set; }
+        public string OutputPath { get; set; }
+
+        public MorphStyle Style { get; set; } = MorphStyle.RaindropReveal;
+        public double PreRollSeconds { get; set; } = 2.0;   // A alone before the morph
+        public double MorphSeconds { get; set; } = 3.0;     // length of the A->B morph window
+        public int Fps { get; set; } = 20;                  // morph-window frame rate (A/B resampled to it)
+        public bool KeepOriginalSize { get; set; } = false; // true: use A's size; false: fit to 766px
+        public int Seed { get; set; } = 20240601;
+
+        // Raindrop-reveal style.
+        public double RainIntensity { get; set; } = 30.0;        // number of drops over the window
+        public double DropSizeVariationPct { get; set; } = 40.0; // +/- variation of each drop's max radius
+        public double SpreadRadius { get; set; } = 90.0;         // px: base max puddle radius
+        public double SpreadVariationPct { get; set; } = 40.0;   // (reserved) extra growth variation
+        public double SoftEdge { get; set; } = 8.0;              // px feather of the puddle edge
+
+        // Tile-flip style.
+        public int Divisions { get; set; } = 8;                                       // cells across the width
+        public TileFlipDirection FlipDirection { get; set; } = TileFlipDirection.Random;
+    }
+
+    // Pure timeline math for the morph (linked into the test project; GifProcessor.Morph uses it to size
+    // the phases). The defining identity is total = preRoll + bDur whenever morph <= bDur.
+    public static class MorphTimeline
+    {
+        // Clamp the morph length so it never exceeds B's length (no point morphing past the end of B).
+        public static double ClampMorph(double morphSeconds, double bDur)
+        {
+            double m = morphSeconds;
+            if (m < 0.0) m = 0.0;
+            if (m > bDur) m = bDur;
+            return m;
+        }
+
+        // Total output length (seconds): preRoll(A) + morph + remaining(B).
+        public static double TotalSeconds(double preRoll, double morphSeconds, double aDur, double bDur)
+        {
+            double pr = preRoll < 0.0 ? 0.0 : preRoll;
+            double m = ClampMorph(morphSeconds, bDur);
+            double remB = bDur - m;
+            if (remB < 0.0) remB = 0.0;
+            return pr + m + remB; // == pr + bDur for m <= bDur
+        }
+    }
+}

--- a/src/Core/RainField.cs
+++ b/src/Core/RainField.cs
@@ -1,0 +1,125 @@
+using System;
+
+namespace GifProcessorApp
+{
+    // Which way the wind pushes the rain. None = straight down; Left/Right add a lateral drift so the
+    // streaks slant. Enum order matches the dialog's direction dropdown index, so
+    // (RainWindDirection)cmbWindDir.SelectedIndex is valid.
+    public enum RainWindDirection
+    {
+        None = 0,
+        Left = 1,
+        Right = 2,
+    }
+
+    // One rain streak for a single frame: the drop head at (X0,Y0) with a motion-blur tail trailing back
+    // to (X1,Y1) (the tail is where the drop was a moment ago, i.e. opposite its velocity).
+    public struct RainStreak
+    {
+        public double X0, Y0; // head (leading point, lower on screen)
+        public double X1, Y1; // tail (trailing point)
+
+        public RainStreak(double x0, double y0, double x1, double y1)
+        {
+            X0 = x0; Y0 = y0; X1 = x1; Y1 = y1;
+        }
+    }
+
+    // Resolved per-canvas rain parameters. RainSettings.ToParams() builds this once the canvas size is
+    // known (the streak count scales with the canvas area).
+    public struct RainParams
+    {
+        public int Count;            // number of simultaneous streaks
+        public double FallSpeed;     // px/sec downward (base; per-drop varied)
+        public double WindX;         // px/sec lateral drift (signed: +right, -left)
+        public double StreakLength;  // px (base; per-drop varied)
+        public int Seed;             // deterministic layout seed
+    }
+
+    // Pure, dependency-free rain math (linked into the test project; RainRenderer rasterizes the streaks
+    // onto a frame). Drops fall continuously and wrap over the canvas, so any time slice is a valid full
+    // rain field and the motion loops seamlessly. The look is a translucent overlay of slanted streaks.
+    public static class RainField
+    {
+        // Deterministic pseudo-random value in [0,1) for drop i / channel salt / seed. No RNG state, so
+        // Streaks() stays pure and reproducible run-to-run.
+        public static double Hash01(int i, int salt, int seed)
+        {
+            unchecked
+            {
+                uint x = (uint)(i * 73856093) ^ (uint)(salt * 19349663) ^ (uint)(seed * 83492791);
+                x ^= x >> 13;
+                x *= 0x5bd1e995u;
+                x ^= x >> 15;
+                return (x & 0xFFFFFFu) / (double)0x1000000;
+            }
+        }
+
+        // Number of streaks for a 0..100 "rain amount" over a canvas, scaled by area and clamped to a
+        // sane range so high settings stay performant.
+        public static int DropCount(double rainAmount, int w, int h)
+        {
+            double amt = rainAmount;
+            if (amt < 0.0) amt = 0.0; else if (amt > 100.0) amt = 100.0;
+            double area = (double)Math.Max(1, w) * Math.Max(1, h);
+            int max = (int)(area / 500.0);
+            if (max < 40) max = 40; else if (max > 1500) max = 1500;
+            return (int)Math.Round(amt / 100.0 * max);
+        }
+
+        // Whole-layer opacity at elapsed time te (seconds within the effect window): 1 normally; if a
+        // "rain stops" fade-out is enabled, ramps 1 -> 0 linearly over the last fadeSeconds of the window.
+        public static double FadeAlpha(double te, double winDur, bool fadeOut, double fadeSeconds)
+        {
+            if (te < 0.0 || te > winDur) return 0.0;
+            if (!fadeOut || fadeSeconds <= 0.0) return 1.0;
+            double fs = fadeSeconds;
+            if (fs > winDur) fs = winDur;
+            double fadeStart = winDur - fs;
+            if (te <= fadeStart) return 1.0;
+            double a = 1.0 - (te - fadeStart) / fs; // 0..1 across the fade
+            return a < 0.0 ? 0.0 : a;
+        }
+
+        // Whether the rain layer is visible at te (inside the window with non-zero opacity). Lets the
+        // caller skip the overlay for frames where there is nothing to draw (pass the source through).
+        public static bool AnyRainActive(double te, double winDur, bool fadeOut, double fadeSeconds)
+        {
+            return FadeAlpha(te, winDur, fadeOut, fadeSeconds) > 0.0;
+        }
+
+        // The streaks for absolute time t (seconds). Heads wrap over the canvas (+ a small top margin so
+        // drops enter from above); each streak trails back along its velocity by StreakLength.
+        public static RainStreak[] Streaks(double t, int w, int h, RainParams p)
+        {
+            int count = p.Count < 0 ? 0 : p.Count;
+            var list = new RainStreak[count];
+            double width = Math.Max(1.0, w);
+            const double margin = 40.0;
+            double height = Math.Max(1.0, h + margin); // wrap height; streaks start above the top
+            for (int i = 0; i < count; i++)
+            {
+                double rx = Hash01(i, 1, p.Seed);
+                double rp = Hash01(i, 2, p.Seed);
+                double rs = 0.7 + 0.6 * Hash01(i, 3, p.Seed); // speed factor 0.7..1.3
+                double rl = 0.7 + 0.6 * Hash01(i, 4, p.Seed); // length factor
+                double vy = p.FallSpeed * rs;
+                double vx = p.WindX * rs;
+                double headY = Mod(rp * height + t * vy, height) - margin;
+                double headX = Mod(rx * width + t * vx, width);
+                double speed = Math.Sqrt(vx * vx + vy * vy);
+                double ux = speed > 1e-6 ? vx / speed : 0.0;
+                double uy = speed > 1e-6 ? vy / speed : 1.0;
+                double len = p.StreakLength * rl;
+                list[i] = new RainStreak(headX, headY, headX - ux * len, headY - uy * len);
+            }
+            return list;
+        }
+
+        private static double Mod(double a, double m)
+        {
+            double r = a % m;
+            return r < 0.0 ? r + m : r;
+        }
+    }
+}

--- a/src/Core/RainRenderer.cs
+++ b/src/Core/RainRenderer.cs
@@ -1,0 +1,82 @@
+using System;
+using ImageMagick;
+
+namespace GifProcessorApp
+{
+    // Draws a translucent rain layer (slanted streaks) over a frame. Like the other effect renderers this
+    // works on a raw RGBA byte[] (Q8) rather than ImageMagick Drawables, so it composites the rain with
+    // explicit alpha blending and dodges Q8 quantization. The streak geometry comes from the pure
+    // RainField; this class only rasterizes it.
+    public static class RainRenderer
+    {
+        // Light, slightly bluish rain colour.
+        private const int RainR = 235, RainG = 240, RainB = 250;
+
+        // Maximum per-pixel opacity of a streak (kept well below 1 so rain stays translucent); the layer
+        // fade scales it further.
+        private const double StrokeAlpha = 0.55;
+
+        // Renders `source` with `streaks` composited on top at whole-layer opacity `alpha` (0..1). Returns
+        // a new image the same size as the source; the caller owns it.
+        public static MagickImage RenderFrame(IMagickImage<byte> source, RainStreak[] streaks, double alpha)
+        {
+            uint w = source.Width;
+            uint h = source.Height;
+            int iw = (int)w;
+            int ih = (int)h;
+
+            byte[] buf;
+            using (var sp = source.GetPixels())
+            {
+                buf = sp.ToByteArray("RGBA")!; // iw*ih*4 bytes, Q8 = 1 byte/channel
+            }
+
+            if (streaks != null && alpha > 0.0)
+            {
+                double a = StrokeAlpha * (alpha < 0.0 ? 0.0 : alpha > 1.0 ? 1.0 : alpha);
+                for (int s = 0; s < streaks.Length; s++)
+                {
+                    DrawLine(buf, iw, ih, streaks[s].X0, streaks[s].Y0, streaks[s].X1, streaks[s].Y1, a);
+                }
+            }
+
+            var settings = new PixelReadSettings(w, h, StorageType.Char, "RGBA");
+            var outImg = new MagickImage();
+            outImg.ReadPixels(buf, settings);
+            outImg.ResetPage(); // uniform full-canvas page so the collection stays Optimize-able
+            return outImg;
+        }
+
+        // Alpha-blends a 1px line (DDA) of rain colour into the RGBA buffer; pixels outside the canvas are
+        // skipped. a is the per-pixel blend factor (0..1).
+        private static void DrawLine(byte[] buf, int w, int h, double x0, double y0, double x1, double y1, double a)
+        {
+            double dx = x1 - x0;
+            double dy = y1 - y0;
+            int steps = (int)Math.Ceiling(Math.Max(Math.Abs(dx), Math.Abs(dy)));
+            if (steps < 1) steps = 1;
+            double sx = dx / steps;
+            double sy = dy / steps;
+            double x = x0;
+            double y = y0;
+            for (int i = 0; i <= steps; i++)
+            {
+                Plot(buf, w, h, (int)Math.Round(x), (int)Math.Round(y), a);
+                x += sx;
+                y += sy;
+            }
+        }
+
+        private static void Plot(byte[] buf, int w, int h, int x, int y, double a)
+        {
+            if ((uint)x >= (uint)w || (uint)y >= (uint)h) return;
+            int idx = (y * w + x) * 4;
+            double inv = 1.0 - a;
+            buf[idx]     = (byte)(buf[idx]     * inv + RainR * a + 0.5);
+            buf[idx + 1] = (byte)(buf[idx + 1] * inv + RainG * a + 0.5);
+            buf[idx + 2] = (byte)(buf[idx + 2] * inv + RainB * a + 0.5);
+            int na = (int)(buf[idx + 3] + a * 255.0 + 0.5); // rain makes transparent areas a bit opaque
+            buf[idx + 3] = na > 255 ? (byte)255 : (byte)na;
+        }
+    }
+}

--- a/src/Core/RainSettings.cs
+++ b/src/Core/RainSettings.cs
@@ -1,0 +1,50 @@
+using System;
+
+namespace GifProcessorApp
+{
+    // Parameters captured from RainDialog and consumed by the GifProcessor rain engine. A translucent
+    // rain layer is drawn over the source (no pixel displacement). Output is a single full-width 766px
+    // GIF (no auto-split), chainable; split later with the main "Split GIF" button. BuildSettings() does
+    // the control->settings mapping in one place so a new field can't be silently dropped on the way out.
+    public class RainSettings
+    {
+        public string InputFilePath { get; set; }
+        public string OutputFilePath { get; set; }
+        public bool IsGif { get; set; }
+
+        // Scene
+        public int Fps { get; set; } = 20;
+        public double DurationSeconds { get; set; } = 6.0;     // effect length (2dp)
+        public double EffectStartSeconds { get; set; } = 0.0;  // GIF "play during" only: where the window begins
+        public bool PlayGifDuringRain { get; set; } = true;    // GIF: rain over live frames vs frozen frame 0
+        public bool KeepOriginalSize { get; set; } = false;    // true: process at native size (no 766px fit)
+
+        // Rain
+        public double RainAmount { get; set; } = 40.0;                                 // 0..100 intensity
+        public RainWindDirection WindDirection { get; set; } = RainWindDirection.None;
+        public double WindStrength { get; set; } = 150.0;                              // px/sec lateral drift magnitude
+        public double DropLength { get; set; } = 16.0;                                 // px streak length (base)
+        public int Seed { get; set; } = 20240601;
+
+        // "Rain stops" fade-out at the end of the window.
+        public bool FadeOut { get; set; } = false;
+        public double FadeOutSeconds { get; set; } = 1.0;
+
+        // Resolve the size-independent dialog values into per-canvas rain parameters.
+        public RainParams ToParams(int w, int h)
+        {
+            double windX = 0.0;
+            if (WindDirection == RainWindDirection.Left) windX = -WindStrength;
+            else if (WindDirection == RainWindDirection.Right) windX = WindStrength;
+
+            return new RainParams
+            {
+                Count = RainField.DropCount(RainAmount, w, h),
+                FallSpeed = Math.Max(120.0, h * 1.2), // px/sec; faster on taller canvases
+                WindX = windX,
+                StreakLength = DropLength,
+                Seed = Seed,
+            };
+        }
+    }
+}

--- a/src/Core/RaindropRevealField.cs
+++ b/src/Core/RaindropRevealField.cs
@@ -1,0 +1,86 @@
+using System;
+
+namespace GifProcessorApp
+{
+    // One raindrop in the reveal: born at BirthT (morph progress in [0,1)), lands at (Px,Py), and its
+    // puddle grows to radius MaxR by the end of the window.
+    public struct RaindropSeed
+    {
+        public double BirthT;
+        public double Px, Py;
+        public double MaxR;
+
+        public RaindropSeed(double birthT, double px, double py, double maxR)
+        {
+            BirthT = birthT; Px = px; Py = py; MaxR = maxR;
+        }
+    }
+
+    // Pure, dependency-free math for the raindrop-reveal morph (linked into the test project;
+    // RaindropRevealRenderer does the Magick blend on top). Coverage(x,y,t) in [0,1] is the fraction of
+    // clip B shown at that pixel: 0 = all A, 1 = all B. As t advances the puddles grow (and a small global
+    // floor near the end guarantees a fully-B frame at t=1), so coverage is monotonically increasing.
+    public static class RaindropRevealField
+    {
+        // Build the deterministic drop schedule for a given canvas. Drops are born within the first 85% of
+        // the window so each has time to spread; positions and sizes come from the seeded hash.
+        public static RaindropSeed[] BuildDrops(MorphSettings s, int w, int h)
+        {
+            int count = (int)Math.Round(s.RainIntensity);
+            if (count < 1) count = 1;
+            var drops = new RaindropSeed[count];
+            double var = s.DropSizeVariationPct / 100.0;
+            for (int i = 0; i < count; i++)
+            {
+                double birth = RainField.Hash01(i, 11, s.Seed) * 0.85;
+                double px = RainField.Hash01(i, 12, s.Seed) * w;
+                double py = RainField.Hash01(i, 13, s.Seed) * h;
+                double sizeFactor = 1.0 + (RainField.Hash01(i, 14, s.Seed) * 2.0 - 1.0) * var;
+                if (sizeFactor < 0.1) sizeFactor = 0.1;
+                drops[i] = new RaindropSeed(birth, px, py, Math.Max(1.0, s.SpreadRadius * sizeFactor));
+            }
+            return drops;
+        }
+
+        public static double SmoothStep(double x)
+        {
+            if (x <= 0.0) return 0.0;
+            if (x >= 1.0) return 1.0;
+            return x * x * (3.0 - 2.0 * x);
+        }
+
+        // Global B floor that ramps 0 -> 1 over the last 15% of the window, so the frame is guaranteed
+        // fully B at t = 1 regardless of where the drops happened to land.
+        public static double GlobalFloor(double t)
+        {
+            return SmoothStep((t - 0.85) / 0.15);
+        }
+
+        // Fraction of B shown at pixel (x,y) at morph progress t (in [0,1]). Union (max) of each born
+        // drop's soft disc, raised to the global floor. `soft` is the edge feather in px.
+        public static double Coverage(double x, double y, double t, RaindropSeed[] drops, double soft)
+        {
+            double cov = GlobalFloor(t);
+            if (cov >= 1.0) return 1.0;
+            double s = soft <= 1e-3 ? 1e-3 : soft;
+            if (drops != null)
+            {
+                for (int i = 0; i < drops.Length; i++)
+                {
+                    RaindropSeed d = drops[i];
+                    if (t <= d.BirthT) continue;
+                    double age = (t - d.BirthT) / Math.Max(1e-3, 1.0 - d.BirthT); // 0..1 over remaining window
+                    double r = d.MaxR * SmoothStep(age);
+                    double dx = x - d.Px, dy = y - d.Py;
+                    double dist = Math.Sqrt(dx * dx + dy * dy);
+                    double v = (r - dist) / s + 0.5; // soft edge: >1 deep inside, <0 outside
+                    if (v <= cov) continue;
+                    double cv = v >= 1.0 ? 1.0 : v;
+                    if (cv > cov) cov = cv;
+                    if (cov >= 1.0) return 1.0;
+                }
+            }
+            return cov < 0.0 ? 0.0 : cov;
+        }
+    }
+}

--- a/src/Core/RaindropRevealRenderer.cs
+++ b/src/Core/RaindropRevealRenderer.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Threading.Tasks;
+using ImageMagick;
+
+namespace GifProcessorApp
+{
+    // Cross-dissolves clip A into clip B per the raindrop coverage mask, one morph frame at a time. Like
+    // the other renderers it works on raw RGBA byte[] (Q8) + Parallel.For: out = A*(1-cov) + B*cov, where
+    // cov is the soft puddle coverage from RaindropRevealField. The soft puddle edges give the "暈開"
+    // spreading look without a separate blur pass.
+    public static class RaindropRevealRenderer
+    {
+        // A and B must already be the same size. Returns a new image the size of A; the caller owns it.
+        public static MagickImage RenderFrame(IMagickImage<byte> frameA, IMagickImage<byte> frameB,
+            double t, RaindropSeed[] drops, double soft)
+        {
+            uint w = frameA.Width;
+            uint h = frameA.Height;
+            int iw = (int)w;
+            int ih = (int)h;
+
+            byte[] a, b;
+            using (var sp = frameA.GetPixels()) a = sp.ToByteArray("RGBA")!;
+            using (var sp = frameB.GetPixels()) b = sp.ToByteArray("RGBA")!;
+            byte[] dst = new byte[a.Length];
+
+            Parallel.For(0, ih, y =>
+            {
+                int rowBase = y * iw * 4;
+                for (int x = 0; x < iw; x++)
+                {
+                    double cov = RaindropRevealField.Coverage(x, y, t, drops, soft);
+                    double inv = 1.0 - cov;
+                    int idx = rowBase + x * 4;
+                    for (int c = 0; c < 4; c++)
+                    {
+                        double v = a[idx + c] * inv + b[idx + c] * cov;
+                        int iv = (int)(v + 0.5);
+                        dst[idx + c] = iv < 0 ? (byte)0 : iv > 255 ? (byte)255 : (byte)iv;
+                    }
+                }
+            });
+
+            var settings = new PixelReadSettings(w, h, StorageType.Char, "RGBA");
+            var outImg = new MagickImage();
+            outImg.ReadPixels(dst, settings);
+            outImg.ResetPage();
+            return outImg;
+        }
+    }
+}

--- a/src/Core/TileFlipGeometry.cs
+++ b/src/Core/TileFlipGeometry.cs
@@ -1,0 +1,76 @@
+using System;
+
+namespace GifProcessorApp
+{
+    // A grid of near-square cells covering the canvas. Cols comes from the user's "divisions across the
+    // width"; Rows is derived so each cell is as close to square as the canvas aspect allows. CellW/CellH
+    // are the nominal (fractional) cell sizes; the renderer rounds per-cell edges so they tile exactly.
+    public struct TileGrid
+    {
+        public int Cols, Rows;
+        public double CellW, CellH;
+
+        public int Count => Cols * Rows;
+    }
+
+    // Pure, dependency-free math for the tile-flip morph (linked into the test project; TileFlipRenderer
+    // does the Magick crop/squash/composite). Each cell flips A->B over a short window staggered (in a
+    // seeded scatter order) across the morph, so the picture assembles piece by piece. All cells are fully
+    // flipped to B at t = 1.
+    public static class TileFlipGeometry
+    {
+        // Split a w x h canvas into `divisions` columns and the row count that keeps cells ~square.
+        public static TileGrid ComputeGrid(int w, int h, int divisions)
+        {
+            int cols = divisions < 1 ? 1 : divisions;
+            double cellW = (double)Math.Max(1, w) / cols;
+            int rows = (int)Math.Round(Math.Max(1, h) / cellW);
+            if (rows < 1) rows = 1;
+            double cellH = (double)Math.Max(1, h) / rows;
+            return new TileGrid { Cols = cols, Rows = rows, CellW = cellW, CellH = cellH };
+        }
+
+        // Per-cell flip progress in [0,1] at morph progress t. Each cell starts at a seeded scatter offset
+        // within [0, 1-flipFraction] and flips over flipFraction of the window; at t=1 every cell is 1.
+        public static double CellPhase(int index, double t, int seed, double flipFraction)
+        {
+            double flip = flipFraction <= 0.0 ? 0.35 : flipFraction;
+            if (flip > 1.0) flip = 1.0;
+            double order = RainField.Hash01(index, 7, seed); // scatter order 0..1
+            double start = order * (1.0 - flip);
+            if (t <= start) return 0.0;
+            double p = (t - start) / flip;
+            return p >= 1.0 ? 1.0 : p;
+        }
+
+        // Squash factor on the flip axis: 1 at phase 0 (face A), 0 at phase 0.5 (edge-on), 1 at phase 1
+        // (face B).
+        public static double CellScale(double phase)
+        {
+            return Math.Abs(1.0 - 2.0 * phase);
+        }
+
+        // The cell shows clip B once it has passed the edge-on midpoint.
+        public static bool CellShowsB(double phase)
+        {
+            return phase >= 0.5;
+        }
+
+        // Flip axis for a cell: 0 = horizontal squash (scaleX), 1 = vertical squash (scaleY). Up/Down flip
+        // vertically, Left/Right horizontally, Random picks per-cell from the seeded hash.
+        public static int CellAxis(int index, TileFlipDirection dir, int seed)
+        {
+            switch (dir)
+            {
+                case TileFlipDirection.Up:
+                case TileFlipDirection.Down:
+                    return 1;
+                case TileFlipDirection.Left:
+                case TileFlipDirection.Right:
+                    return 0;
+                default:
+                    return RainField.Hash01(index, 8, seed) < 0.5 ? 0 : 1;
+            }
+        }
+    }
+}

--- a/src/Core/TileFlipRenderer.cs
+++ b/src/Core/TileFlipRenderer.cs
@@ -1,0 +1,65 @@
+using System;
+using ImageMagick;
+
+namespace GifProcessorApp
+{
+    // Renders one tile-flip morph frame: for each grid cell, crop the cell from A or B (whichever face is
+    // showing), squash it on the flip axis by the cell's current scale, and composite it centred in the
+    // cell's rectangle. Cells not yet started show A at full size; finished cells show B at full size. The
+    // grid math is the pure TileFlipGeometry; this class only does the Magick crop/resize/composite.
+    public static class TileFlipRenderer
+    {
+        private const double FlipFraction = 0.35; // each cell's flip occupies 35% of the morph window
+
+        // A and B must already be the same size. Returns a new canvas the size of A; the caller owns it.
+        public static MagickImage RenderFrame(IMagickImage<byte> frameA, IMagickImage<byte> frameB,
+            double t, TileGrid grid, MorphSettings settings)
+        {
+            int w = (int)frameA.Width;
+            int h = (int)frameA.Height;
+            var canvas = new MagickImage(MagickColors.Transparent, (uint)w, (uint)h);
+
+            for (int r = 0; r < grid.Rows; r++)
+            {
+                int y0 = (int)Math.Round((double)r * h / grid.Rows);
+                int y1 = (int)Math.Round((double)(r + 1) * h / grid.Rows);
+                int ch = Math.Max(1, y1 - y0);
+
+                for (int c = 0; c < grid.Cols; c++)
+                {
+                    int x0 = (int)Math.Round((double)c * w / grid.Cols);
+                    int x1 = (int)Math.Round((double)(c + 1) * w / grid.Cols);
+                    int cw = Math.Max(1, x1 - x0);
+
+                    int index = r * grid.Cols + c;
+                    double phase = TileFlipGeometry.CellPhase(index, t, settings.Seed, FlipFraction);
+                    bool showB = TileFlipGeometry.CellShowsB(phase);
+                    IMagickImage<byte> srcFrame = showB ? frameB : frameA;
+
+                    using var cell = (MagickImage)srcFrame.Clone();
+                    cell.Crop(new MagickGeometry(x0, y0, (uint)cw, (uint)ch));
+                    cell.ResetPage();
+
+                    double scale = TileFlipGeometry.CellScale(phase);
+                    if (scale >= 0.999)
+                    {
+                        canvas.Composite(cell, x0, y0, CompositeOperator.Over);
+                        continue;
+                    }
+
+                    int axis = TileFlipGeometry.CellAxis(index, settings.FlipDirection, settings.Seed);
+                    int sw = axis == 0 ? Math.Max(1, (int)Math.Round(cw * scale)) : cw;
+                    int sh = axis == 1 ? Math.Max(1, (int)Math.Round(ch * scale)) : ch;
+                    cell.Resize(new MagickGeometry((uint)sw, (uint)sh) { IgnoreAspectRatio = true });
+
+                    int cx = x0 + (cw - sw) / 2;
+                    int cy = y0 + (ch - sh) / 2;
+                    canvas.Composite(cell, cx, cy, CompositeOperator.Over);
+                }
+            }
+
+            canvas.ResetPage();
+            return canvas;
+        }
+    }
+}

--- a/src/Dialogs/MorphTransitionDialog.cs
+++ b/src/Dialogs/MorphTransitionDialog.cs
@@ -1,0 +1,411 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.IO;
+using System.Windows.Forms;
+using SteamGifCropper.Properties;
+
+namespace GifProcessorApp
+{
+    // A->B "morph" transition dialog: A plays for a pre-roll, morphs into B over the morph window, then
+    // B's remaining footage plays to the end. Mirrors the other dialogs' inline layout + theme handling.
+    // A style combo (raindrop reveal / tile flip) shows/hides the matching parameter group, like the wind
+    // dialog's Normal/Nuclear groups. BuildSettings() does the control->settings mapping in one place.
+    public class MorphTransitionDialog : Form
+    {
+        private TextBox txtInputA = null!;
+        private Button btnBrowseA = null!;
+        private TextBox txtInputB = null!;
+        private Button btnBrowseB = null!;
+        private TextBox txtOutput = null!;
+        private Button btnBrowseOutput = null!;
+        private Label lblInputA = null!;
+        private Label lblInputB = null!;
+        private Label lblOutput = null!;
+
+        private Label lblStyle = null!;
+        private ComboBox cmbStyle = null!;
+
+        private Label lblPreRoll = null!;
+        private NumericUpDown numPreRoll = null!;
+        private Label lblMorph = null!;
+        private NumericUpDown numMorph = null!;
+        private Label lblFps = null!;
+        private NumericUpDown numFps = null!;
+        private CheckBox chkKeepSize = null!;
+
+        // Raindrop-reveal group.
+        private Label lblRainIntensity = null!;
+        private NumericUpDown numRainIntensity = null!;
+        private Label lblDropSizeVar = null!;
+        private NumericUpDown numDropSizeVar = null!;
+        private Label lblSpreadRadius = null!;
+        private NumericUpDown numSpreadRadius = null!;
+        private Label lblSoftEdge = null!;
+        private NumericUpDown numSoftEdge = null!;
+
+        // Tile-flip group.
+        private Label lblDivisions = null!;
+        private NumericUpDown numDivisions = null!;
+        private Label lblFlipDir = null!;
+        private ComboBox cmbFlipDir = null!;
+
+        private readonly List<Control> _raindropControls = new List<Control>();
+        private readonly List<Control> _tileControls = new List<Control>();
+
+        private Button btnOK = null!;
+        private Button btnCancel = null!;
+
+        public MorphTransitionDialog()
+        {
+            InitializeComponent();
+            cmbStyle.SelectedIndexChanged += (s, e) => RefreshStyleVisibility();
+            UpdateUIText();
+            RefreshStyleVisibility();
+            ApplyTheme();
+        }
+
+        public MorphSettings BuildSettings()
+        {
+            return new MorphSettings
+            {
+                InputAPath = txtInputA.Text,
+                InputBPath = txtInputB.Text,
+                OutputPath = txtOutput.Text,
+                Style = cmbStyle.SelectedIndex == 1 ? MorphStyle.TileFlip : MorphStyle.RaindropReveal,
+                PreRollSeconds = (double)numPreRoll.Value,
+                MorphSeconds = (double)numMorph.Value,
+                Fps = (int)numFps.Value,
+                KeepOriginalSize = chkKeepSize.Checked,
+                RainIntensity = (double)numRainIntensity.Value,
+                DropSizeVariationPct = (double)numDropSizeVar.Value,
+                SpreadRadius = (double)numSpreadRadius.Value,
+                SoftEdge = (double)numSoftEdge.Value,
+                Divisions = (int)numDivisions.Value,
+                FlipDirection = (TileFlipDirection)cmbFlipDir.SelectedIndex,
+            };
+        }
+
+        private void RefreshStyleVisibility()
+        {
+            bool tile = cmbStyle.SelectedIndex == 1;
+            foreach (var c in _raindropControls) c.Visible = !tile;
+            foreach (var c in _tileControls) c.Visible = tile;
+        }
+
+        private void UpdateUIText()
+        {
+            Text = Resources.MorphDialog_Title;
+            lblInputA.Text = Resources.MorphDialog_InputA;
+            lblInputB.Text = Resources.MorphDialog_InputB;
+            lblOutput.Text = Resources.QuickDialog_OutputLabel;
+            lblStyle.Text = Resources.MorphDialog_Style;
+            lblPreRoll.Text = Resources.MorphDialog_PreRoll;
+            lblMorph.Text = Resources.MorphDialog_MorphSeconds;
+            lblFps.Text = Resources.SlotDialog_Fps;
+            chkKeepSize.Text = Resources.Dialog_KeepOriginalSize;
+            lblRainIntensity.Text = Resources.MorphDialog_RainIntensity;
+            lblDropSizeVar.Text = Resources.MorphDialog_DropSizeVar;
+            lblSpreadRadius.Text = Resources.MorphDialog_SpreadRadius;
+            lblSoftEdge.Text = Resources.MorphDialog_SoftEdge;
+            lblDivisions.Text = Resources.MorphDialog_Divisions;
+            lblFlipDir.Text = Resources.MorphDialog_FlipDir;
+            btnBrowseA.Text = Resources.Button_Browse;
+            btnBrowseB.Text = Resources.Button_Browse;
+            btnBrowseOutput.Text = Resources.Button_Browse;
+            btnOK.Text = Resources.ScrollDialog_OK;
+            btnCancel.Text = Resources.ScrollDialog_Cancel;
+
+            int styleSel = cmbStyle.SelectedIndex < 0 ? 0 : cmbStyle.SelectedIndex;
+            cmbStyle.Items.Clear();
+            cmbStyle.Items.Add(Resources.MorphStyle_Raindrop);
+            cmbStyle.Items.Add(Resources.MorphStyle_TileFlip);
+            cmbStyle.SelectedIndex = styleSel;
+
+            int dirSel = cmbFlipDir.SelectedIndex < 0 ? 0 : cmbFlipDir.SelectedIndex;
+            cmbFlipDir.Items.Clear();
+            cmbFlipDir.Items.Add(Resources.FlipDir_Random);
+            cmbFlipDir.Items.Add(Resources.FlipDir_Up);
+            cmbFlipDir.Items.Add(Resources.FlipDir_Down);
+            cmbFlipDir.Items.Add(Resources.FlipDir_Left);
+            cmbFlipDir.Items.Add(Resources.FlipDir_Right);
+            cmbFlipDir.SelectedIndex = dirSel;
+        }
+
+        private void ApplyTheme()
+        {
+            bool isDark = WindowsThemeManager.IsDarkModeEnabled();
+            if (isDark)
+            {
+                BackColor = Color.FromArgb(32, 32, 32);
+                ForeColor = Color.White;
+                ApplyDarkThemeToControls(Controls);
+            }
+            else
+            {
+                BackColor = SystemColors.Control;
+                ForeColor = SystemColors.ControlText;
+                ApplyLightThemeToControls(Controls);
+            }
+
+            if (IsHandleCreated)
+            {
+                WindowsThemeManager.SetDarkModeForWindow(Handle, isDark);
+            }
+        }
+
+        protected override void SetVisibleCore(bool value)
+        {
+            base.SetVisibleCore(value);
+            if (value && IsHandleCreated)
+            {
+                WindowsThemeManager.SetDarkModeForWindow(Handle, WindowsThemeManager.IsDarkModeEnabled());
+            }
+        }
+
+        private void ApplyDarkThemeToControls(Control.ControlCollection controls)
+        {
+            foreach (Control control in controls)
+            {
+                if (control is Label || control is CheckBox)
+                {
+                    control.BackColor = Color.Transparent;
+                    control.ForeColor = Color.White;
+                }
+                else if (control is TextBox textBox)
+                {
+                    textBox.BackColor = Color.FromArgb(64, 64, 64);
+                    textBox.ForeColor = Color.White;
+                }
+                else if (control is Button button)
+                {
+                    button.BackColor = Color.FromArgb(64, 64, 64);
+                    button.ForeColor = Color.White;
+                    button.FlatStyle = FlatStyle.Flat;
+                    button.FlatAppearance.BorderColor = Color.FromArgb(128, 128, 128);
+                }
+                else if (control is NumericUpDown numericUpDown)
+                {
+                    numericUpDown.BackColor = Color.FromArgb(64, 64, 64);
+                    numericUpDown.ForeColor = Color.White;
+                }
+                else if (control is ComboBox comboBox)
+                {
+                    comboBox.BackColor = Color.FromArgb(64, 64, 64);
+                    comboBox.ForeColor = Color.White;
+                }
+
+                if (control.HasChildren)
+                {
+                    ApplyDarkThemeToControls(control.Controls);
+                }
+            }
+        }
+
+        private void ApplyLightThemeToControls(Control.ControlCollection controls)
+        {
+            foreach (Control control in controls)
+            {
+                if (control is Label || control is CheckBox)
+                {
+                    control.BackColor = Color.Transparent;
+                    control.ForeColor = SystemColors.ControlText;
+                }
+                else if (control is TextBox textBox)
+                {
+                    textBox.BackColor = SystemColors.Window;
+                    textBox.ForeColor = SystemColors.WindowText;
+                }
+                else if (control is Button button)
+                {
+                    button.BackColor = SystemColors.Control;
+                    button.ForeColor = SystemColors.ControlText;
+                    button.FlatStyle = FlatStyle.Standard;
+                    button.UseVisualStyleBackColor = true;
+                }
+                else if (control is NumericUpDown numericUpDown)
+                {
+                    numericUpDown.BackColor = SystemColors.Window;
+                    numericUpDown.ForeColor = SystemColors.WindowText;
+                }
+                else if (control is ComboBox comboBox)
+                {
+                    comboBox.BackColor = SystemColors.Window;
+                    comboBox.ForeColor = SystemColors.WindowText;
+                }
+
+                if (control.HasChildren)
+                {
+                    ApplyLightThemeToControls(control.Controls);
+                }
+            }
+        }
+
+        private void BrowseInput(TextBox target, string suffix)
+        {
+            using var ofd = new OpenFileDialog
+            {
+                Filter = Resources.FileDialog_ImageAndGifFilter,
+                Title = Resources.QuickDialog_InputLabel
+            };
+            if (ofd.ShowDialog() == DialogResult.OK)
+            {
+                target.Text = ofd.FileName;
+                if (string.IsNullOrWhiteSpace(txtOutput.Text) && !string.IsNullOrWhiteSpace(txtInputA.Text))
+                {
+                    string dir = Path.GetDirectoryName(txtInputA.Text) ?? string.Empty;
+                    string name = Path.GetFileNameWithoutExtension(txtInputA.Text) + "_morph.gif";
+                    txtOutput.Text = Path.Combine(dir, name);
+                }
+            }
+        }
+
+        private void BtnBrowseA_Click(object? sender, EventArgs e) => BrowseInput(txtInputA, "_morph");
+        private void BtnBrowseB_Click(object? sender, EventArgs e) => BrowseInput(txtInputB, "_morph");
+
+        private void BtnBrowseOutput_Click(object? sender, EventArgs e)
+        {
+            using var sfd = new SaveFileDialog
+            {
+                Filter = Resources.FileDialog_GifFilter,
+                Title = Resources.QuickDialog_OutputLabel,
+                FileName = string.IsNullOrEmpty(txtInputA.Text)
+                    ? "output_morph.gif"
+                    : Path.GetFileNameWithoutExtension(txtInputA.Text) + "_morph.gif"
+            };
+            if (sfd.ShowDialog() == DialogResult.OK)
+            {
+                txtOutput.Text = sfd.FileName;
+            }
+        }
+
+        private void BtnOK_Click(object? sender, EventArgs e)
+        {
+            if (string.IsNullOrWhiteSpace(txtInputA.Text) || !File.Exists(txtInputA.Text) ||
+                string.IsNullOrWhiteSpace(txtInputB.Text) || !File.Exists(txtInputB.Text))
+            {
+                MessageBox.Show(this, Resources.ScrollDialog_InputRequired, Resources.Title_Error, MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                return;
+            }
+            if (string.IsNullOrWhiteSpace(txtOutput.Text))
+            {
+                MessageBox.Show(this, Resources.ScrollDialog_OutputRequired, Resources.Title_Error, MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                return;
+            }
+            DialogResult = DialogResult.OK;
+            Close();
+        }
+
+        private static NumericUpDown MakeNum(int x, int y, int width, int decimals, decimal min, decimal max, decimal inc, decimal val)
+        {
+            var n = new NumericUpDown
+            {
+                Location = new Point(x, y),
+                Size = new Size(width, 23),
+                DecimalPlaces = decimals,
+            };
+            n.Minimum = min;   // set range before value so the value isn't clamped to the default 0..100
+            n.Maximum = max;
+            n.Increment = inc;
+            n.Value = val;
+            return n;
+        }
+
+        private void InitializeComponent()
+        {
+            lblInputA = new Label { Location = new Point(14, 9), Size = new Size(360, 20), Text = "Clip A" };
+            txtInputA = new TextBox { Location = new Point(14, 29), Size = new Size(418, 23), ReadOnly = true };
+            btnBrowseA = new Button { Location = new Point(440, 27), Size = new Size(86, 25), Text = "Browse", UseVisualStyleBackColor = true };
+            btnBrowseA.Click += BtnBrowseA_Click;
+
+            lblInputB = new Label { Location = new Point(14, 58), Size = new Size(360, 20), Text = "Clip B" };
+            txtInputB = new TextBox { Location = new Point(14, 78), Size = new Size(418, 23), ReadOnly = true };
+            btnBrowseB = new Button { Location = new Point(440, 76), Size = new Size(86, 25), Text = "Browse", UseVisualStyleBackColor = true };
+            btnBrowseB.Click += BtnBrowseB_Click;
+
+            lblOutput = new Label { Location = new Point(14, 107), Size = new Size(360, 20), Text = "Output" };
+            txtOutput = new TextBox { Location = new Point(14, 127), Size = new Size(418, 23), ReadOnly = true };
+            btnBrowseOutput = new Button { Location = new Point(440, 125), Size = new Size(86, 25), Text = "Browse", UseVisualStyleBackColor = true };
+            btnBrowseOutput.Click += BtnBrowseOutput_Click;
+
+            // Style + shared timeline
+            lblStyle = new Label { Location = new Point(14, 165), Size = new Size(56, 20), Text = "Style" };
+            cmbStyle = new ComboBox { Location = new Point(72, 163), Size = new Size(180, 23), DropDownStyle = ComboBoxStyle.DropDownList };
+
+            lblPreRoll = new Label { Location = new Point(14, 198), Size = new Size(116, 20), Text = "Pre-roll A" };
+            numPreRoll = MakeNum(132, 196, 56, 2, 0.00m, 120.00m, 0.25m, 2.00m);
+            lblMorph = new Label { Location = new Point(196, 198), Size = new Size(76, 20), Text = "Morph" };
+            numMorph = MakeNum(274, 196, 56, 2, 0.10m, 120.00m, 0.25m, 3.00m);
+            lblFps = new Label { Location = new Point(338, 198), Size = new Size(34, 20), Text = "FPS" };
+            numFps = MakeNum(374, 196, 46, 0, 5m, 60m, 1m, 20m);
+            // Keep-size goes on the style row (its own space) so the long localized label isn't clipped.
+            chkKeepSize = new CheckBox { Location = new Point(270, 166), Size = new Size(252, 22), Text = "Keep original size", UseVisualStyleBackColor = true };
+
+            // --- Raindrop-reveal group ---
+            lblRainIntensity = new Label { Location = new Point(14, 234), Size = new Size(74, 20), Text = "Drops" };
+            numRainIntensity = MakeNum(96, 232, 56, 0, 1m, 400m, 1m, 30m);
+            lblDropSizeVar = new Label { Location = new Point(162, 234), Size = new Size(88, 20), Text = "Size var %" };
+            numDropSizeVar = MakeNum(256, 232, 56, 0, 0m, 100m, 1m, 40m);
+            lblSpreadRadius = new Label { Location = new Point(14, 267), Size = new Size(74, 20), Text = "Spread r" };
+            numSpreadRadius = MakeNum(96, 265, 56, 0, 8m, 600m, 2m, 90m);
+            lblSoftEdge = new Label { Location = new Point(162, 267), Size = new Size(88, 20), Text = "Soft edge" };
+            numSoftEdge = MakeNum(256, 265, 56, 0, 1m, 80m, 1m, 8m);
+
+            // --- Tile-flip group (same vertical band) ---
+            lblDivisions = new Label { Location = new Point(14, 234), Size = new Size(74, 20), Text = "Divisions" };
+            numDivisions = MakeNum(96, 232, 56, 0, 2m, 40m, 1m, 8m);
+            lblFlipDir = new Label { Location = new Point(162, 234), Size = new Size(60, 20), Text = "Flip dir" };
+            cmbFlipDir = new ComboBox { Location = new Point(228, 232), Size = new Size(140, 23), DropDownStyle = ComboBoxStyle.DropDownList };
+
+            btnOK = new Button { Location = new Point(363, 312), Size = new Size(75, 25), Text = "OK", UseVisualStyleBackColor = true };
+            btnOK.Click += BtnOK_Click;
+            btnCancel = new Button { Location = new Point(444, 312), Size = new Size(82, 25), Text = "Cancel", DialogResult = DialogResult.Cancel, UseVisualStyleBackColor = true };
+
+            _raindropControls.AddRange(new Control[]
+            {
+                lblRainIntensity, numRainIntensity, lblDropSizeVar, numDropSizeVar,
+                lblSpreadRadius, numSpreadRadius, lblSoftEdge, numSoftEdge,
+            });
+            _tileControls.AddRange(new Control[] { lblDivisions, numDivisions, lblFlipDir, cmbFlipDir });
+
+            SuspendLayout();
+            Controls.Add(lblInputA);
+            Controls.Add(txtInputA);
+            Controls.Add(btnBrowseA);
+            Controls.Add(lblInputB);
+            Controls.Add(txtInputB);
+            Controls.Add(btnBrowseB);
+            Controls.Add(lblOutput);
+            Controls.Add(txtOutput);
+            Controls.Add(btnBrowseOutput);
+            Controls.Add(lblStyle);
+            Controls.Add(cmbStyle);
+            Controls.Add(lblPreRoll);
+            Controls.Add(numPreRoll);
+            Controls.Add(lblMorph);
+            Controls.Add(numMorph);
+            Controls.Add(lblFps);
+            Controls.Add(numFps);
+            Controls.Add(chkKeepSize);
+            foreach (var c in _raindropControls) Controls.Add(c);
+            foreach (var c in _tileControls) Controls.Add(c);
+            Controls.Add(btnOK);
+            Controls.Add(btnCancel);
+
+            AutoScaleDimensions = new SizeF(7F, 15F);
+            AutoScaleMode = AutoScaleMode.Font;
+            CancelButton = btnCancel;
+            AcceptButton = btnOK;
+            ClientSize = new Size(540, 352);
+            FormBorderStyle = FormBorderStyle.FixedDialog;
+            MaximizeBox = false;
+            MinimizeBox = false;
+            Name = "MorphTransitionDialog";
+            StartPosition = FormStartPosition.CenterParent;
+            Text = "Morph A to B";
+            ResumeLayout(false);
+            PerformLayout();
+        }
+    }
+}

--- a/src/Dialogs/QuicksandDialog.cs
+++ b/src/Dialogs/QuicksandDialog.cs
@@ -438,9 +438,9 @@ namespace GifProcessorApp
             //
             // lblDuration
             //
-            lblDuration.Location = new System.Drawing.Point(168, 126);
+            lblDuration.Location = new System.Drawing.Point(164, 126);
             lblDuration.Name = "lblDuration";
-            lblDuration.Size = new System.Drawing.Size(96, 20);
+            lblDuration.Size = new System.Drawing.Size(100, 20);
             lblDuration.TabIndex = 8;
             lblDuration.Text = "Duration";
             //

--- a/src/Dialogs/RainDialog.cs
+++ b/src/Dialogs/RainDialog.cs
@@ -1,0 +1,393 @@
+#nullable enable
+using System;
+using System.Drawing;
+using System.IO;
+using System.Windows.Forms;
+using SteamGifCropper.Properties;
+
+namespace GifProcessorApp
+{
+    // Rain-overlay (下雨) parameters dialog. Mirrors the other effect dialogs' inline layout + theme
+    // handling. A translucent rain layer (amount / wind direction / wind strength / streak length, with an
+    // optional "rain stops" fade-out) is drawn over the chosen [start, duration] window. BuildSettings()
+    // does the control->settings mapping in one place.
+    public class RainDialog : Form
+    {
+        private readonly bool _isGif;
+
+        private TextBox txtInputPath = null!;
+        private Button btnBrowseInput = null!;
+        private TextBox txtOutputPath = null!;
+        private Button btnBrowseOutput = null!;
+        private Label lblInput = null!;
+        private Label lblOutput = null!;
+
+        private Label lblRainAmount = null!;
+        private NumericUpDown numRainAmount = null!;
+        private Label lblWindDir = null!;
+        private ComboBox cmbWindDir = null!;
+        private Label lblWindStrength = null!;
+        private NumericUpDown numWindStrength = null!;
+
+        private Label lblDuration = null!;
+        private NumericUpDown numDuration = null!;
+        private Label lblFps = null!;
+        private NumericUpDown numFps = null!;
+        private Label lblStart = null!;
+        private NumericUpDown numStart = null!;
+
+        private Label lblDropLength = null!;
+        private NumericUpDown numDropLength = null!;
+        private CheckBox chkFadeOut = null!;
+        private Label lblFadeSeconds = null!;
+        private NumericUpDown numFadeSeconds = null!;
+
+        private ComboBox cmbGifPlayMode = null!;
+        private CheckBox chkKeepSize = null!;
+
+        private Button btnOK = null!;
+        private Button btnCancel = null!;
+
+        public RainDialog(bool gifMode)
+        {
+            _isGif = gifMode;
+            InitializeComponent();
+            cmbGifPlayMode.Visible = gifMode;
+            chkFadeOut.CheckedChanged += (s, e) => RefreshFadeEnabled();
+            cmbGifPlayMode.SelectedIndexChanged += (s, e) => RefreshStartEnabled();
+            UpdateUIText();
+            RefreshFadeEnabled();
+            RefreshStartEnabled();
+            ApplyTheme();
+        }
+
+        // Single place that turns the controls into a settings object (avoids the "forgot to copy a
+        // field" bug class).
+        public RainSettings BuildSettings(bool isGif)
+        {
+            return new RainSettings
+            {
+                InputFilePath = txtInputPath.Text,
+                OutputFilePath = txtOutputPath.Text,
+                IsGif = isGif,
+                Fps = (int)numFps.Value,
+                DurationSeconds = (double)numDuration.Value,
+                EffectStartSeconds = (double)numStart.Value,
+                PlayGifDuringRain = cmbGifPlayMode.SelectedIndex == 0,
+                KeepOriginalSize = chkKeepSize.Checked,
+                RainAmount = (double)numRainAmount.Value,
+                WindDirection = (RainWindDirection)cmbWindDir.SelectedIndex,
+                WindStrength = (double)numWindStrength.Value,
+                DropLength = (double)numDropLength.Value,
+                FadeOut = chkFadeOut.Checked,
+                FadeOutSeconds = (double)numFadeSeconds.Value,
+            };
+        }
+
+        private void RefreshFadeEnabled()
+        {
+            numFadeSeconds.Enabled = chkFadeOut.Checked;
+        }
+
+        private void RefreshStartEnabled()
+        {
+            // The effect start window only applies to GIF "rain over playback".
+            numStart.Enabled = _isGif && cmbGifPlayMode.SelectedIndex == 0;
+        }
+
+        private void UpdateUIText()
+        {
+            Text = Resources.RainDialog_Title;
+            lblInput.Text = Resources.QuickDialog_InputLabel;
+            lblOutput.Text = Resources.QuickDialog_OutputLabel;
+            lblRainAmount.Text = Resources.RainDialog_RainAmount;
+            lblWindDir.Text = Resources.RainDialog_WindDir;
+            lblWindStrength.Text = Resources.RainDialog_WindStrength;
+            lblDuration.Text = Resources.QuickDialog_Duration;
+            lblFps.Text = Resources.SlotDialog_Fps;
+            lblStart.Text = Resources.Dialog_StartSeconds;
+            lblDropLength.Text = Resources.RainDialog_DropLength;
+            chkFadeOut.Text = Resources.RainDialog_FadeOut;
+            lblFadeSeconds.Text = Resources.RainDialog_FadeSeconds;
+            chkKeepSize.Text = Resources.Dialog_KeepOriginalSize;
+            btnBrowseInput.Text = Resources.Button_Browse;
+            btnBrowseOutput.Text = Resources.Button_Browse;
+            btnOK.Text = Resources.ScrollDialog_OK;
+            btnCancel.Text = Resources.ScrollDialog_Cancel;
+
+            int dirSel = cmbWindDir.SelectedIndex < 0 ? 0 : cmbWindDir.SelectedIndex;
+            cmbWindDir.Items.Clear();
+            cmbWindDir.Items.Add(Resources.RainDir_None);
+            cmbWindDir.Items.Add(Resources.RainDir_Left);
+            cmbWindDir.Items.Add(Resources.RainDir_Right);
+            cmbWindDir.SelectedIndex = dirSel;
+
+            int playSel = cmbGifPlayMode.SelectedIndex < 0 ? 0 : cmbGifPlayMode.SelectedIndex;
+            cmbGifPlayMode.Items.Clear();
+            cmbGifPlayMode.Items.Add(Resources.RainDialog_GifPlayDuring);
+            cmbGifPlayMode.Items.Add(Resources.RainDialog_GifFreeze);
+            cmbGifPlayMode.SelectedIndex = playSel;
+        }
+
+        private void ApplyTheme()
+        {
+            bool isDark = WindowsThemeManager.IsDarkModeEnabled();
+            if (isDark)
+            {
+                BackColor = Color.FromArgb(32, 32, 32);
+                ForeColor = Color.White;
+                ApplyDarkThemeToControls(Controls);
+            }
+            else
+            {
+                BackColor = SystemColors.Control;
+                ForeColor = SystemColors.ControlText;
+                ApplyLightThemeToControls(Controls);
+            }
+
+            if (IsHandleCreated)
+            {
+                WindowsThemeManager.SetDarkModeForWindow(Handle, isDark);
+            }
+        }
+
+        protected override void SetVisibleCore(bool value)
+        {
+            base.SetVisibleCore(value);
+            if (value && IsHandleCreated)
+            {
+                WindowsThemeManager.SetDarkModeForWindow(Handle, WindowsThemeManager.IsDarkModeEnabled());
+            }
+        }
+
+        private void ApplyDarkThemeToControls(Control.ControlCollection controls)
+        {
+            foreach (Control control in controls)
+            {
+                if (control is Label || control is CheckBox)
+                {
+                    control.BackColor = Color.Transparent;
+                    control.ForeColor = Color.White;
+                }
+                else if (control is TextBox textBox)
+                {
+                    textBox.BackColor = Color.FromArgb(64, 64, 64);
+                    textBox.ForeColor = Color.White;
+                }
+                else if (control is Button button)
+                {
+                    button.BackColor = Color.FromArgb(64, 64, 64);
+                    button.ForeColor = Color.White;
+                    button.FlatStyle = FlatStyle.Flat;
+                    button.FlatAppearance.BorderColor = Color.FromArgb(128, 128, 128);
+                }
+                else if (control is NumericUpDown numericUpDown)
+                {
+                    numericUpDown.BackColor = Color.FromArgb(64, 64, 64);
+                    numericUpDown.ForeColor = Color.White;
+                }
+                else if (control is ComboBox comboBox)
+                {
+                    comboBox.BackColor = Color.FromArgb(64, 64, 64);
+                    comboBox.ForeColor = Color.White;
+                }
+
+                if (control.HasChildren)
+                {
+                    ApplyDarkThemeToControls(control.Controls);
+                }
+            }
+        }
+
+        private void ApplyLightThemeToControls(Control.ControlCollection controls)
+        {
+            foreach (Control control in controls)
+            {
+                if (control is Label || control is CheckBox)
+                {
+                    control.BackColor = Color.Transparent;
+                    control.ForeColor = SystemColors.ControlText;
+                }
+                else if (control is TextBox textBox)
+                {
+                    textBox.BackColor = SystemColors.Window;
+                    textBox.ForeColor = SystemColors.WindowText;
+                }
+                else if (control is Button button)
+                {
+                    button.BackColor = SystemColors.Control;
+                    button.ForeColor = SystemColors.ControlText;
+                    button.FlatStyle = FlatStyle.Standard;
+                    button.UseVisualStyleBackColor = true;
+                }
+                else if (control is NumericUpDown numericUpDown)
+                {
+                    numericUpDown.BackColor = SystemColors.Window;
+                    numericUpDown.ForeColor = SystemColors.WindowText;
+                }
+                else if (control is ComboBox comboBox)
+                {
+                    comboBox.BackColor = SystemColors.Window;
+                    comboBox.ForeColor = SystemColors.WindowText;
+                }
+
+                if (control.HasChildren)
+                {
+                    ApplyLightThemeToControls(control.Controls);
+                }
+            }
+        }
+
+        private void BtnBrowseInput_Click(object? sender, EventArgs e)
+        {
+            using var ofd = new OpenFileDialog
+            {
+                Filter = _isGif ? Resources.FileDialog_GifAndWebpFilter : Resources.FileDialog_ImageAndGifFilter,
+                Title = Resources.QuickDialog_InputLabel
+            };
+            if (ofd.ShowDialog() == DialogResult.OK)
+            {
+                txtInputPath.Text = ofd.FileName;
+                if (string.IsNullOrWhiteSpace(txtOutputPath.Text))
+                {
+                    string dir = Path.GetDirectoryName(ofd.FileName) ?? string.Empty;
+                    string name = Path.GetFileNameWithoutExtension(ofd.FileName) + "_rain.gif";
+                    txtOutputPath.Text = Path.Combine(dir, name);
+                }
+            }
+        }
+
+        private void BtnBrowseOutput_Click(object? sender, EventArgs e)
+        {
+            using var sfd = new SaveFileDialog
+            {
+                Filter = Resources.FileDialog_GifFilter,
+                Title = Resources.QuickDialog_OutputLabel,
+                FileName = string.IsNullOrEmpty(txtInputPath.Text)
+                    ? "output_rain.gif"
+                    : Path.GetFileNameWithoutExtension(txtInputPath.Text) + "_rain.gif"
+            };
+            if (sfd.ShowDialog() == DialogResult.OK)
+            {
+                txtOutputPath.Text = sfd.FileName;
+            }
+        }
+
+        private void BtnOK_Click(object? sender, EventArgs e)
+        {
+            if (string.IsNullOrWhiteSpace(txtInputPath.Text) || !File.Exists(txtInputPath.Text))
+            {
+                MessageBox.Show(this, Resources.ScrollDialog_InputRequired, Resources.Title_Error, MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                return;
+            }
+            if (string.IsNullOrWhiteSpace(txtOutputPath.Text))
+            {
+                MessageBox.Show(this, Resources.ScrollDialog_OutputRequired, Resources.Title_Error, MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                return;
+            }
+            DialogResult = DialogResult.OK;
+            Close();
+        }
+
+        private static NumericUpDown MakeNum(int x, int y, int width, int decimals, decimal min, decimal max, decimal inc, decimal val)
+        {
+            var n = new NumericUpDown
+            {
+                Location = new Point(x, y),
+                Size = new Size(width, 23),
+                DecimalPlaces = decimals,
+            };
+            n.Minimum = min;   // set range before value so the value isn't clamped to the default 0..100
+            n.Maximum = max;
+            n.Increment = inc;
+            n.Value = val;
+            return n;
+        }
+
+        private void InitializeComponent()
+        {
+            lblInput = new Label { Location = new Point(14, 9), Size = new Size(360, 20), Text = "Input" };
+            txtInputPath = new TextBox { Location = new Point(14, 29), Size = new Size(418, 23), ReadOnly = true };
+            btnBrowseInput = new Button { Location = new Point(440, 27), Size = new Size(86, 25), Text = "Browse", UseVisualStyleBackColor = true };
+            btnBrowseInput.Click += BtnBrowseInput_Click;
+            lblOutput = new Label { Location = new Point(14, 58), Size = new Size(360, 20), Text = "Output" };
+            txtOutputPath = new TextBox { Location = new Point(14, 78), Size = new Size(418, 23), ReadOnly = true };
+            btnBrowseOutput = new Button { Location = new Point(440, 76), Size = new Size(86, 25), Text = "Browse", UseVisualStyleBackColor = true };
+            btnBrowseOutput.Click += BtnBrowseOutput_Click;
+
+            // Rain row
+            lblRainAmount = new Label { Location = new Point(14, 116), Size = new Size(90, 20), Text = "Rain amount" };
+            numRainAmount = MakeNum(106, 114, 56, 0, 0m, 100m, 1m, 40m);
+            lblWindDir = new Label { Location = new Point(178, 116), Size = new Size(40, 20), Text = "Wind" };
+            cmbWindDir = new ComboBox { Location = new Point(220, 114), Size = new Size(110, 23), DropDownStyle = ComboBoxStyle.DropDownList };
+            lblWindStrength = new Label { Location = new Point(344, 116), Size = new Size(64, 20), Text = "Strength" };
+            numWindStrength = MakeNum(410, 114, 60, 0, 0m, 1200m, 10m, 150m);
+
+            // Scene row
+            lblDuration = new Label { Location = new Point(14, 149), Size = new Size(100, 20), Text = "Duration" };
+            numDuration = MakeNum(116, 147, 56, 2, 0.10m, 120.00m, 0.25m, 6.00m);
+            lblFps = new Label { Location = new Point(178, 149), Size = new Size(34, 20), Text = "FPS" };
+            numFps = MakeNum(214, 147, 46, 0, 5m, 60m, 1m, 20m);
+            lblStart = new Label { Location = new Point(280, 149), Size = new Size(80, 20), Text = "Start" };
+            numStart = MakeNum(362, 147, 56, 2, 0.00m, 120.00m, 0.25m, 0.00m);
+
+            // Look + fade row
+            lblDropLength = new Label { Location = new Point(14, 182), Size = new Size(90, 20), Text = "Streak len" };
+            numDropLength = MakeNum(106, 180, 56, 0, 4m, 80m, 1m, 16m);
+            chkFadeOut = new CheckBox { Location = new Point(178, 181), Size = new Size(210, 22), Text = "Rain stops (fade out)" };
+            lblFadeSeconds = new Label { Location = new Point(392, 182), Size = new Size(70, 20), Text = "Fade (s)" };
+            numFadeSeconds = MakeNum(466, 180, 56, 2, 0.10m, 30.00m, 0.25m, 1.00m);
+
+            // Playback mode (GIF only) + keep size
+            cmbGifPlayMode = new ComboBox { Location = new Point(14, 214), Size = new Size(200, 23), DropDownStyle = ComboBoxStyle.DropDownList };
+            chkKeepSize = new CheckBox { Location = new Point(230, 215), Size = new Size(280, 22), Text = "Keep original size", UseVisualStyleBackColor = true };
+
+            btnOK = new Button { Location = new Point(363, 252), Size = new Size(75, 25), Text = "OK", UseVisualStyleBackColor = true };
+            btnOK.Click += BtnOK_Click;
+            btnCancel = new Button { Location = new Point(444, 252), Size = new Size(82, 25), Text = "Cancel", DialogResult = DialogResult.Cancel, UseVisualStyleBackColor = true };
+
+            SuspendLayout();
+            Controls.Add(lblInput);
+            Controls.Add(txtInputPath);
+            Controls.Add(btnBrowseInput);
+            Controls.Add(lblOutput);
+            Controls.Add(txtOutputPath);
+            Controls.Add(btnBrowseOutput);
+            Controls.Add(lblRainAmount);
+            Controls.Add(numRainAmount);
+            Controls.Add(lblWindDir);
+            Controls.Add(cmbWindDir);
+            Controls.Add(lblWindStrength);
+            Controls.Add(numWindStrength);
+            Controls.Add(lblDuration);
+            Controls.Add(numDuration);
+            Controls.Add(lblFps);
+            Controls.Add(numFps);
+            Controls.Add(lblStart);
+            Controls.Add(numStart);
+            Controls.Add(lblDropLength);
+            Controls.Add(numDropLength);
+            Controls.Add(chkFadeOut);
+            Controls.Add(lblFadeSeconds);
+            Controls.Add(numFadeSeconds);
+            Controls.Add(cmbGifPlayMode);
+            Controls.Add(chkKeepSize);
+            Controls.Add(btnOK);
+            Controls.Add(btnCancel);
+
+            AutoScaleDimensions = new SizeF(7F, 15F);
+            AutoScaleMode = AutoScaleMode.Font;
+            CancelButton = btnCancel;
+            AcceptButton = btnOK;
+            ClientSize = new Size(540, 292);
+            FormBorderStyle = FormBorderStyle.FixedDialog;
+            MaximizeBox = false;
+            MinimizeBox = false;
+            Name = "RainDialog";
+            StartPosition = FormStartPosition.CenterParent;
+            Text = "Rain";
+            ResumeLayout(false);
+            PerformLayout();
+        }
+    }
+}

--- a/src/Dialogs/RippleDialog.cs
+++ b/src/Dialogs/RippleDialog.cs
@@ -469,11 +469,11 @@ namespace GifProcessorApp
             btnBrowseOutput.Click += BtnBrowseOutput_Click;
 
             // Scene row
-            lblDuration = new Label { Location = new Point(14, 114), Size = new Size(70, 20), Text = "Duration" };
-            numDuration = MakeNum(88, 112, 56, 2, 0.10m, 30.00m, 0.25m, 4.00m);
-            lblFps = new Label { Location = new Point(152, 114), Size = new Size(34, 20), Text = "FPS" };
-            numFps = MakeNum(188, 112, 46, 0, 5m, 60m, 1m, 20m);
-            cmbGifPlayMode = new ComboBox { Location = new Point(244, 112), Size = new Size(200, 23), DropDownStyle = ComboBoxStyle.DropDownList };
+            lblDuration = new Label { Location = new Point(14, 114), Size = new Size(100, 20), Text = "Duration" };
+            numDuration = MakeNum(116, 112, 56, 2, 0.10m, 30.00m, 0.25m, 4.00m);
+            lblFps = new Label { Location = new Point(178, 114), Size = new Size(34, 20), Text = "FPS" };
+            numFps = MakeNum(214, 112, 46, 0, 5m, 60m, 1m, 20m);
+            cmbGifPlayMode = new ComboBox { Location = new Point(266, 112), Size = new Size(200, 23), DropDownStyle = ComboBoxStyle.DropDownList };
 
             // Medium A
             lblWaveSpeed = new Label { Location = new Point(14, 147), Size = new Size(66, 20), Text = "Speed" };

--- a/src/Dialogs/WindDialog.cs
+++ b/src/Dialogs/WindDialog.cs
@@ -410,12 +410,12 @@ namespace GifProcessorApp
             cmbMode = new ComboBox { Location = new Point(320, 112), Size = new Size(150, 23), DropDownStyle = ComboBoxStyle.DropDownList };
 
             // Scene row
-            lblDuration = new Label { Location = new Point(14, 147), Size = new Size(60, 20), Text = "Duration" };
-            numDuration = MakeNum(76, 145, 56, 2, 0.10m, 60.00m, 0.25m, 6.00m);
-            lblFps = new Label { Location = new Point(140, 147), Size = new Size(30, 20), Text = "FPS" };
-            numFps = MakeNum(172, 145, 46, 0, 5m, 60m, 1m, 20m);
-            lblStart = new Label { Location = new Point(232, 147), Size = new Size(84, 20), Text = "Start" };
-            numStart = MakeNum(320, 145, 56, 2, 0.00m, 60.00m, 0.25m, 0.00m);
+            lblDuration = new Label { Location = new Point(14, 147), Size = new Size(100, 20), Text = "Duration" };
+            numDuration = MakeNum(116, 145, 56, 2, 0.10m, 60.00m, 0.25m, 6.00m);
+            lblFps = new Label { Location = new Point(178, 147), Size = new Size(30, 20), Text = "FPS" };
+            numFps = MakeNum(210, 145, 46, 0, 5m, 60m, 1m, 20m);
+            lblStart = new Label { Location = new Point(262, 147), Size = new Size(84, 20), Text = "Start" };
+            numStart = MakeNum(348, 145, 56, 2, 0.00m, 60.00m, 0.25m, 0.00m);
 
             // Medium row 1
             lblWavelength = new Label { Location = new Point(14, 180), Size = new Size(64, 20), Text = "Wavelen" };

--- a/src/Forms/GTMainForm.Designer.cs
+++ b/src/Forms/GTMainForm.Designer.cs
@@ -84,6 +84,9 @@
             btnRippleGif = new System.Windows.Forms.Button();
             btnWindStatic = new System.Windows.Forms.Button();
             btnWindGif = new System.Windows.Forms.Button();
+            btnRainStatic = new System.Windows.Forms.Button();
+            btnRainGif = new System.Windows.Forms.Button();
+            btnMorphTransition = new System.Windows.Forms.Button();
             chkAutoFitSplit = new System.Windows.Forms.CheckBox();
             numUpDownTargetKB = new System.Windows.Forms.NumericUpDown();
             lblAutoFitTries = new System.Windows.Forms.Label();
@@ -150,7 +153,7 @@
             // pBarTaskStatus
             // 
             pBarTaskStatus.Dock = System.Windows.Forms.DockStyle.Bottom;
-            pBarTaskStatus.Location = new System.Drawing.Point(0, 534);
+            pBarTaskStatus.Location = new System.Drawing.Point(0, 596);
             pBarTaskStatus.Margin = new System.Windows.Forms.Padding(2);
             pBarTaskStatus.Name = "pBarTaskStatus";
             pBarTaskStatus.Size = new System.Drawing.Size(619, 20);
@@ -159,7 +162,7 @@
             // lblStatus
             // 
             lblStatus.Dock = System.Windows.Forms.DockStyle.Bottom;
-            lblStatus.Location = new System.Drawing.Point(0, 519);
+            lblStatus.Location = new System.Drawing.Point(0, 581);
             lblStatus.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             lblStatus.Name = "lblStatus";
             lblStatus.Size = new System.Drawing.Size(619, 15);
@@ -212,7 +215,7 @@
             panelGifsicle.Controls.Add(numUpDownPalette);
             panelGifsicle.Controls.Add(lblPaletteDesc);
             panelGifsicle.Dock = System.Windows.Forms.DockStyle.Bottom;
-            panelGifsicle.Location = new System.Drawing.Point(0, 400);
+            panelGifsicle.Location = new System.Drawing.Point(0, 462);
             panelGifsicle.Margin = new System.Windows.Forms.Padding(2);
             panelGifsicle.Name = "panelGifsicle";
             panelGifsicle.Size = new System.Drawing.Size(619, 175);
@@ -500,7 +503,7 @@
             // lblFramerate
             // 
             lblFramerate.AutoSize = true;
-            lblFramerate.Location = new System.Drawing.Point(11, 377);
+            lblFramerate.Location = new System.Drawing.Point(11, 439);
             lblFramerate.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             lblFramerate.Name = "lblFramerate";
             lblFramerate.Size = new System.Drawing.Size(0, 15);
@@ -509,7 +512,7 @@
             // lblFPS
             // 
             lblFPS.AutoSize = true;
-            lblFPS.Location = new System.Drawing.Point(310, 377);
+            lblFPS.Location = new System.Drawing.Point(310, 439);
             lblFPS.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             lblFPS.Name = "lblFPS";
             lblFPS.Size = new System.Drawing.Size(0, 15);
@@ -537,7 +540,7 @@
             // 
             // btnLanguageChange
             // 
-            btnLanguageChange.Location = new System.Drawing.Point(548, 349);
+            btnLanguageChange.Location = new System.Drawing.Point(548, 411);
             btnLanguageChange.Name = "btnLanguageChange";
             btnLanguageChange.Size = new System.Drawing.Size(64, 26);
             btnLanguageChange.TabIndex = 16;
@@ -615,7 +618,7 @@
             // lblResourceLimitDesc
             // 
             lblResourceLimitDesc.AutoSize = true;
-            lblResourceLimitDesc.Location = new System.Drawing.Point(7, 351);
+            lblResourceLimitDesc.Location = new System.Drawing.Point(7, 413);
             lblResourceLimitDesc.Name = "lblResourceLimitDesc";
             lblResourceLimitDesc.Size = new System.Drawing.Size(234, 15);
             lblResourceLimitDesc.TabIndex = 15;
@@ -623,7 +626,7 @@
             // 
             // numUpDownFramerate
             // 
-            numUpDownFramerate.Location = new System.Drawing.Point(255, 375);
+            numUpDownFramerate.Location = new System.Drawing.Point(255, 437);
             numUpDownFramerate.Margin = new System.Windows.Forms.Padding(2);
             numUpDownFramerate.Maximum = new decimal(new int[] { 30, 0, 0, 0 });
             numUpDownFramerate.Minimum = new decimal(new int[] { 5, 0, 0, 0 });
@@ -732,12 +735,42 @@
             btnWindGif.UseVisualStyleBackColor = true;
             btnWindGif.Click += btnWindGif_Click;
             //
+            // btnRainStatic
+            //
+            btnRainStatic.Location = new System.Drawing.Point(7, 348);
+            btnRainStatic.Name = "btnRainStatic";
+            btnRainStatic.Size = new System.Drawing.Size(300, 26);
+            btnRainStatic.TabIndex = 27;
+            btnRainStatic.Text = SteamGifCropper.Properties.Resources.Button_RainStatic;
+            btnRainStatic.UseVisualStyleBackColor = true;
+            btnRainStatic.Click += btnRainStatic_Click;
+            //
+            // btnRainGif
+            //
+            btnRainGif.Location = new System.Drawing.Point(313, 348);
+            btnRainGif.Name = "btnRainGif";
+            btnRainGif.Size = new System.Drawing.Size(300, 26);
+            btnRainGif.TabIndex = 28;
+            btnRainGif.Text = SteamGifCropper.Properties.Resources.Button_RainGif;
+            btnRainGif.UseVisualStyleBackColor = true;
+            btnRainGif.Click += btnRainGif_Click;
+            //
+            // btnMorphTransition
+            //
+            btnMorphTransition.Location = new System.Drawing.Point(7, 379);
+            btnMorphTransition.Name = "btnMorphTransition";
+            btnMorphTransition.Size = new System.Drawing.Size(606, 26);
+            btnMorphTransition.TabIndex = 29;
+            btnMorphTransition.Text = SteamGifCropper.Properties.Resources.Button_MorphTransition;
+            btnMorphTransition.UseVisualStyleBackColor = true;
+            btnMorphTransition.Click += btnMorphTransition_Click;
+            //
             // GifToolMainForm
             //
             AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
             AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
-            ClientSize = new System.Drawing.Size(619, 618);
+            ClientSize = new System.Drawing.Size(619, 680);
             Controls.Add(lblResourceLimitDesc);
             Controls.Add(btnResizeNfpsGIF);
             Controls.Add(btnOverlayGIF);
@@ -768,6 +801,9 @@
             Controls.Add(btnRippleGif);
             Controls.Add(btnWindStatic);
             Controls.Add(btnWindGif);
+            Controls.Add(btnRainStatic);
+            Controls.Add(btnRainGif);
+            Controls.Add(btnMorphTransition);
             Icon = (System.Drawing.Icon)resources.GetObject("$this.Icon");
             Margin = new System.Windows.Forms.Padding(2);
             Name = "GifToolMainForm";
@@ -848,6 +884,9 @@
         private System.Windows.Forms.Button btnRippleGif;
         private System.Windows.Forms.Button btnWindStatic;
         private System.Windows.Forms.Button btnWindGif;
+        private System.Windows.Forms.Button btnRainStatic;
+        private System.Windows.Forms.Button btnRainGif;
+        private System.Windows.Forms.Button btnMorphTransition;
         public System.Windows.Forms.CheckBox chkAutoFitSplit;
         public System.Windows.Forms.NumericUpDown numUpDownTargetKB;
         private System.Windows.Forms.Label lblAutoFitTries;

--- a/src/Forms/GTMainForm.cs
+++ b/src/Forms/GTMainForm.cs
@@ -269,6 +269,21 @@ namespace GifProcessorApp
             await ExecuteWithErrorHandling(async () => await GifProcessor.WindGif(this), "wind sway (GIF)");
         }
 
+        private async void btnRainStatic_Click(object sender, EventArgs e)
+        {
+            await ExecuteWithErrorHandling(async () => await GifProcessor.RainStaticImage(this), "rain overlay (image)");
+        }
+
+        private async void btnRainGif_Click(object sender, EventArgs e)
+        {
+            await ExecuteWithErrorHandling(async () => await GifProcessor.RainGif(this), "rain overlay (GIF)");
+        }
+
+        private async void btnMorphTransition_Click(object sender, EventArgs e)
+        {
+            await ExecuteWithErrorHandling(async () => await GifProcessor.MorphTransition(this), "morph transition (A→B)");
+        }
+
         private async void btnGifsicleSingle_Click(object sender, EventArgs e)
         {
             await ExecuteWithErrorHandling(async () => await GifProcessor.OptimizeSingleGif(this), "gifsicle optimization");


### PR DESCRIPTION
## Summary
- **Rain overlay** (main UI): a translucent rain layer drawn over a GIF/image - rain amount, wind direction/strength, streak length, start/duration, optional "rain stops" fade-out. Sibling to the Wind effect (play-along / frozen-then-play).
- **A->B morph transition** (new dialog + button): A plays a pre-roll, morphs into B over the morph window (A fully gone by the end), then B''s remaining footage plays. Two styles - **raindrop-spread reveal** and **tile flip** (auto near-square grid, random/fixed direction). Timeline `total = preRoll + B_duration`, distinct from the concat overlap model.
- **UI/localization fixes**: removed `(766px)` from Quicksand/Ripple/Wind titles; widened the localized `(秒)` labels (Rain/Ripple/Morph/Wind/Quicksand); moved the Morph keep-size checkbox to its own row; rain playback dropdown now uses rain-specific strings.
- **SIMD**: deferred per decision - `Parallel.For` kept; hotspots + benchmark-gated path documented.

## Implementation notes
- Pure math/geometry split into dependency-free files linked into the test project; Magick renderers kept separate (rain streaks rasterized directly into the RGBA buffer, matching the repo''s no-Drawables convention).
- New engine partials `GifProcessor.Rain.cs` / `GifProcessor.Morph.cs`; main form grew one button-row block (+62px).

## Testing
- `dotnet build SteamGifCropper.sln` -> 0 warnings / 0 errors.
- Full xUnit suite: **243 tests, 0 failures** (29 new: pure-math + renderer smoke tests).
- Note: the GUI/visual output of the new effects was not verified headlessly - recommend running the app with a sample GIF.

🤖 Generated with [Claude Code](https://claude.com/claude-code)