### PR TITLE
feat(morph): add Brick plank-drop A-to-B morph style

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,7 +120,7 @@ Each dialog handles one specific operation type:
 - `RippleDropPickerForm` - Click-to-pick a ripple drop position on frame 0
 - `WindDialog` - Wind sway (風吹麥田): travelling-wave displacement, normal/nuclear modes (image / GIF)
 - `RainDialog` - Rain overlay: translucent slanted streaks, wind + "rain stops" fade-out (image / GIF)
-- `MorphTransitionDialog` - A→B morph transition (raindrop reveal / tile flip / spotlight / jigsaw) with a pre-roll + remaining-B timeline
+- `MorphTransitionDialog` - A→B morph transition (raindrop reveal / tile flip / spotlight / jigsaw / brick drop) with a pre-roll + remaining-B timeline
 
 > **Creative-effects detail:** these "766px single-output, chainable" effects (grid mosaic, slot
 > machine, quicksand, ripple, wind, rain, A→B morph) — their ideas and completion status live in
@@ -129,9 +129,9 @@ Each dialog handles one specific operation type:
 > Their math is extracted into pure, dependency-free files for unit testing — `SlotMachineGeometry.cs`,
 > `QuicksandGeometry.cs`, `GifEffectWindow.cs`, `GridMosaicGeometry.cs`, `RippleField.cs`,
 > `WindField.cs`, `RainField.cs`, `RaindropRevealField.cs`, `TileFlipGeometry.cs`, `SpotlightField.cs`,
-> `JigsawGeometry.cs`, `MorphSettings.cs` (`MorphTimeline`) (+ the Magick-side `RippleRenderer.cs`,
-> `GridMosaicRenderer.cs`, `RaindropRevealRenderer.cs`, `TileFlipRenderer.cs`, `SpotlightRenderer.cs`,
-> `JigsawRenderer.cs`) — linked into the test project (pure files only).
+> `JigsawGeometry.cs`, `BrickField.cs`, `MorphSettings.cs` (`MorphTimeline`) (+ the Magick-side
+> `RippleRenderer.cs`, `GridMosaicRenderer.cs`, `RaindropRevealRenderer.cs`, `TileFlipRenderer.cs`,
+> `SpotlightRenderer.cs`, `JigsawRenderer.cs`, `BrickRenderer.cs`) — linked into the test project (pure files only).
 > The A→B morph uses its own `pre-roll + morph window + remaining-B` timeline (total = pre-roll + B
 > duration), distinct from the concat overlap model; it lives in `GifProcessor.Morph.cs` /
 > `MorphTransitionDialog`, not in `TransitionGenerator`.
@@ -334,6 +334,7 @@ SteamGifCropper/
 │   │   ├── TileFlipGeometry/Renderer.cs              # Morph tile flip (Geometry pure, Renderer Magick)
 │   │   ├── SpotlightField/Renderer.cs               # Morph spotlight (Field pure, Renderer Magick)
 │   │   ├── JigsawGeometry/Renderer.cs              # Morph jigsaw (Geometry pure, Renderer Magick)
+│   │   ├── BrickField/Renderer.cs                  # Morph brick drop (Field pure physics, Renderer Magick)
 │   │   └── GifProcessor.{Rain,Morph,Wind,...}.cs     # Per-effect engine partials (RunXxx + Build*)
 │   ├── Forms/
 │   │   ├── GTMainForm.cs                   # Main UI form

--- a/Properties/Resources.Designer.cs
+++ b/Properties/Resources.Designer.cs
@@ -2567,6 +2567,72 @@ namespace SteamGifCropper.Properties {
             }
         }
 
+        internal static string MorphStyle_Brick {
+            get {
+                return ResourceManager.GetString("MorphStyle_Brick", resourceCulture);
+            }
+        }
+
+        internal static string MorphDialog_BrickPieces {
+            get {
+                return ResourceManager.GetString("MorphDialog_BrickPieces", resourceCulture);
+            }
+        }
+
+        internal static string MorphDialog_BrickDir {
+            get {
+                return ResourceManager.GetString("MorphDialog_BrickDir", resourceCulture);
+            }
+        }
+
+        internal static string MorphDialog_BrickHeight {
+            get {
+                return ResourceManager.GetString("MorphDialog_BrickHeight", resourceCulture);
+            }
+        }
+
+        internal static string MorphDialog_BrickGravity {
+            get {
+                return ResourceManager.GetString("MorphDialog_BrickGravity", resourceCulture);
+            }
+        }
+
+        internal static string MorphDialog_BrickWeight {
+            get {
+                return ResourceManager.GetString("MorphDialog_BrickWeight", resourceCulture);
+            }
+        }
+
+        internal static string MorphDialog_BrickHardness {
+            get {
+                return ResourceManager.GetString("MorphDialog_BrickHardness", resourceCulture);
+            }
+        }
+
+        internal static string BrickDir_Down {
+            get {
+                return ResourceManager.GetString("BrickDir_Down", resourceCulture);
+            }
+        }
+
+        internal static string BrickDir_Up {
+            get {
+                return ResourceManager.GetString("BrickDir_Up", resourceCulture);
+            }
+        }
+
+        internal static string BrickDir_Left {
+            get {
+                return ResourceManager.GetString("BrickDir_Left", resourceCulture);
+            }
+        }
+
+        internal static string BrickDir_Right {
+            get {
+                return ResourceManager.GetString("BrickDir_Right", resourceCulture);
+            }
+        }
+
         internal static string MorphDialog_SpotRadius {
             get {
                 return ResourceManager.GetString("MorphDialog_SpotRadius", resourceCulture);

--- a/Properties/Resources.ja.resx
+++ b/Properties/Resources.ja.resx
@@ -1378,6 +1378,39 @@ FFmpeg 出力（切り捨て）:
   <data name="MorphStyle_Jigsaw" xml:space="preserve">
     <value>ジグソー</value>
   </data>
+  <data name="MorphStyle_Brick" xml:space="preserve">
+    <value>ブロック落下</value>
+  </data>
+  <data name="MorphDialog_BrickPieces" xml:space="preserve">
+    <value>枚数</value>
+  </data>
+  <data name="MorphDialog_BrickDir" xml:space="preserve">
+    <value>方向</value>
+  </data>
+  <data name="MorphDialog_BrickHeight" xml:space="preserve">
+    <value>高さm</value>
+  </data>
+  <data name="MorphDialog_BrickGravity" xml:space="preserve">
+    <value>g</value>
+  </data>
+  <data name="MorphDialog_BrickWeight" xml:space="preserve">
+    <value>重さ</value>
+  </data>
+  <data name="MorphDialog_BrickHardness" xml:space="preserve">
+    <value>硬さ</value>
+  </data>
+  <data name="BrickDir_Down" xml:space="preserve">
+    <value>下</value>
+  </data>
+  <data name="BrickDir_Up" xml:space="preserve">
+    <value>上</value>
+  </data>
+  <data name="BrickDir_Left" xml:space="preserve">
+    <value>左</value>
+  </data>
+  <data name="BrickDir_Right" xml:space="preserve">
+    <value>右</value>
+  </data>
   <data name="MorphDialog_SpotRadius" xml:space="preserve">
     <value>光の大きさ</value>
   </data>

--- a/Properties/Resources.resx
+++ b/Properties/Resources.resx
@@ -1377,6 +1377,39 @@ Technical details: {5}</value>
   <data name="MorphStyle_Jigsaw" xml:space="preserve">
     <value>Jigsaw</value>
   </data>
+  <data name="MorphStyle_Brick" xml:space="preserve">
+    <value>Brick drop</value>
+  </data>
+  <data name="MorphDialog_BrickPieces" xml:space="preserve">
+    <value>Pieces</value>
+  </data>
+  <data name="MorphDialog_BrickDir" xml:space="preserve">
+    <value>Dir</value>
+  </data>
+  <data name="MorphDialog_BrickHeight" xml:space="preserve">
+    <value>Height m</value>
+  </data>
+  <data name="MorphDialog_BrickGravity" xml:space="preserve">
+    <value>g</value>
+  </data>
+  <data name="MorphDialog_BrickWeight" xml:space="preserve">
+    <value>Weight</value>
+  </data>
+  <data name="MorphDialog_BrickHardness" xml:space="preserve">
+    <value>Hardness</value>
+  </data>
+  <data name="BrickDir_Down" xml:space="preserve">
+    <value>Down</value>
+  </data>
+  <data name="BrickDir_Up" xml:space="preserve">
+    <value>Up</value>
+  </data>
+  <data name="BrickDir_Left" xml:space="preserve">
+    <value>Left</value>
+  </data>
+  <data name="BrickDir_Right" xml:space="preserve">
+    <value>Right</value>
+  </data>
   <data name="MorphDialog_SpotRadius" xml:space="preserve">
     <value>Light size</value>
   </data>

--- a/Properties/Resources.zh-TW.resx
+++ b/Properties/Resources.zh-TW.resx
@@ -1378,6 +1378,39 @@ FFmpeg 輸出 (部分)：
   <data name="MorphStyle_Jigsaw" xml:space="preserve">
     <value>拼圖</value>
   </data>
+  <data name="MorphStyle_Brick" xml:space="preserve">
+    <value>疊磚</value>
+  </data>
+  <data name="MorphDialog_BrickPieces" xml:space="preserve">
+    <value>塊數</value>
+  </data>
+  <data name="MorphDialog_BrickDir" xml:space="preserve">
+    <value>方向</value>
+  </data>
+  <data name="MorphDialog_BrickHeight" xml:space="preserve">
+    <value>高度m</value>
+  </data>
+  <data name="MorphDialog_BrickGravity" xml:space="preserve">
+    <value>g</value>
+  </data>
+  <data name="MorphDialog_BrickWeight" xml:space="preserve">
+    <value>重量</value>
+  </data>
+  <data name="MorphDialog_BrickHardness" xml:space="preserve">
+    <value>硬度</value>
+  </data>
+  <data name="BrickDir_Down" xml:space="preserve">
+    <value>向下</value>
+  </data>
+  <data name="BrickDir_Up" xml:space="preserve">
+    <value>向上</value>
+  </data>
+  <data name="BrickDir_Left" xml:space="preserve">
+    <value>向左</value>
+  </data>
+  <data name="BrickDir_Right" xml:space="preserve">
+    <value>向右</value>
+  </data>
   <data name="MorphDialog_SpotRadius" xml:space="preserve">
     <value>光圈大小</value>
   </data>

--- a/SteamGifCropper.Tests/BrickFieldTests.cs
+++ b/SteamGifCropper.Tests/BrickFieldTests.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Linq;
+using GifProcessorApp;
+
+namespace SteamGifCropper.Tests;
+
+public class BrickFieldTests
+{
+    private static BrickParams Params(BrickDirection dir = BrickDirection.Down, int pieces = 10) => new BrickParams
+    {
+        Pieces = pieces,
+        Direction = dir,
+        TotalHeightM = 5.0,
+        Gravity = 9.8,
+        Weight = 1.0,
+        Hardness = 0.5,
+    };
+
+    [Fact]
+    public void Planks_AtEnd_AllLandedAtTheirSlot()
+    {
+        var planks = BrickField.Planks(1.0, Params(), 400);
+        Assert.Equal(10, planks.Length);
+        foreach (var pl in planks)
+        {
+            Assert.True(pl.Started);
+            Assert.Equal(pl.SliceStart, pl.CurrentPos); // at rest -> full B
+        }
+    }
+
+    [Fact]
+    public void Planks_SlicesTileTheAxis()
+    {
+        int L = 400;
+        var planks = BrickField.Planks(1.0, Params(pieces: 7), L);
+        Assert.Equal(L, planks.Sum(p => p.SliceLen));
+        Assert.Equal(0, planks.Min(p => p.SliceStart));
+        Assert.Equal(L, planks.Max(p => p.SliceStart + p.SliceLen));
+    }
+
+    [Fact]
+    public void Planks_AtStart_FirstIsFallingOffScreen_RestNotStarted()
+    {
+        var planks = BrickField.Planks(0.0, Params(), 400);
+        Assert.True(planks[0].Started);
+        Assert.True(planks[0].CurrentPos < 0); // Down starts just above the top edge
+        Assert.False(planks[9].Started);
+    }
+
+    [Fact]
+    public void Planks_DropOrderStaggered_MoreStartedOverTime()
+    {
+        int early = BrickField.Planks(0.1, Params(), 400).Count(p => p.Started);
+        int late = BrickField.Planks(0.6, Params(), 400).Count(p => p.Started);
+        Assert.True(late > early);
+    }
+
+    [Fact]
+    public void Direction_DeterminesWhichSliceDropsFirst()
+    {
+        // Down stacks from the bottom: drop order 0 fills the bottom slice (largest SliceStart).
+        var down = BrickField.Planks(1.0, Params(BrickDirection.Down), 400);
+        Assert.Equal(down.Max(p => p.SliceStart), down[0].SliceStart);
+        // Up stacks from the top: drop order 0 fills the top slice (SliceStart 0).
+        var up = BrickField.Planks(1.0, Params(BrickDirection.Up), 400);
+        Assert.Equal(0, up[0].SliceStart);
+    }
+
+    [Fact]
+    public void IsVertical_MatchesDirection()
+    {
+        Assert.True(BrickField.IsVertical(BrickDirection.Down));
+        Assert.True(BrickField.IsVertical(BrickDirection.Up));
+        Assert.False(BrickField.IsVertical(BrickDirection.Left));
+        Assert.False(BrickField.IsVertical(BrickDirection.Right));
+    }
+}

--- a/SteamGifCropper.Tests/MorphRainRendererTests.cs
+++ b/SteamGifCropper.Tests/MorphRainRendererTests.cs
@@ -122,4 +122,21 @@ public class MorphRainRendererTests
         Assert.Equal(80u, outImg.Width);
         Assert.Equal(50u, outImg.Height);
     }
+
+    [Theory]
+    [InlineData(BrickDirection.Down, 0.0)]
+    [InlineData(BrickDirection.Down, 0.5)]
+    [InlineData(BrickDirection.Down, 1.0)]
+    [InlineData(BrickDirection.Up, 0.5)]
+    [InlineData(BrickDirection.Left, 0.5)]
+    [InlineData(BrickDirection.Right, 0.5)]
+    public void BrickRenderer_PreservesDimensions(BrickDirection dir, double t)
+    {
+        using var a = new MagickImage(MagickColors.Red, 80, 50);
+        using var b = new MagickImage(MagickColors.Blue, 80, 50);
+        var p = new BrickParams { Pieces = 8, Direction = dir, TotalHeightM = 5, Gravity = 9.8, Weight = 1, Hardness = 0.5 };
+        using var outImg = BrickRenderer.RenderFrame(a, b, t, p);
+        Assert.Equal(80u, outImg.Width);
+        Assert.Equal(50u, outImg.Height);
+    }
 }

--- a/SteamGifCropper.Tests/SteamGifCropper.Tests.csproj
+++ b/SteamGifCropper.Tests/SteamGifCropper.Tests.csproj
@@ -61,6 +61,8 @@
     <Compile Include="..\src\Core\JigsawGeometry.cs" Link="JigsawGeometry.cs" />
     <Compile Include="..\src\Core\SpotlightRenderer.cs" Link="SpotlightRenderer.cs" />
     <Compile Include="..\src\Core\JigsawRenderer.cs" Link="JigsawRenderer.cs" />
+    <Compile Include="..\src\Core\BrickField.cs" Link="BrickField.cs" />
+    <Compile Include="..\src\Core\BrickRenderer.cs" Link="BrickRenderer.cs" />
     <Compile Include="..\src\Core\GridMosaicSettings.cs" Link="GridMosaicSettings.cs" />
     <Compile Include="..\src\Core\GridMosaicRenderer.cs" Link="GridMosaicRenderer.cs" />
     <Compile Include="..\src\Core\GifConcatenationSettings.cs" Link="GifConcatenationSettings.cs" />

--- a/docs/CreativeEffectsDevLog.md
+++ b/docs/CreativeEffectsDevLog.md
@@ -272,3 +272,13 @@
 - `MorphTransitionDialog`：`cmbStyle` 加 2 項（enum 順序＝combo 順序，`Style=(MorphStyle)SelectedIndex`）；`_spotlightControls`/`_jigsawControls` 兩組與既有兩組共用同一 y 帶、依 style 顯示；Jigsaw 色票 `pnlJigsawColor`（`chkJigsawLines` 連動 enable）。
 - 新增 **8** 鍵（三語 + Designer）：`MorphStyle_Spotlight/Jigsaw`、`MorphDialog_SpotRadius/SpotSpeed/SpotExpand/JigsawPieces/JigsawShowLines/JigsawLineColor`。
 - 測試：`SpotlightFieldTests`(6：bounce 範圍、center 邊界、expand 凍結、末幀半徑=對角線、coverage 內/外、末幀全 B)、`JigsawGeometryTests`(3：piece phase 起迄+單調、line alpha)、`MorphRainRendererTests` 加 spotlight/jigsaw 各 3 例 smoke。test csproj 連結 `SpotlightField`/`JigsawGeometry`(純) + `SpotlightRenderer`/`JigsawRenderer`。build 0 warning、全 **236** 例綠燈。
+
+## 疊圖轉換再加 1 風格：Brick（疊磚／木板掉落）
+
+`MorphStyle` 第 5 種。把畫面沿掉落軸切成 N 片「木板」，**底圖 A 持續播放**，B 的木板由遠端一片片掉下來、撞底**彈跳**後疊好，全部疊完＝全 B。每片木板畫的是**它最終位置的 B 切片**（掉落過程中內容固定，不是掃過區段的內容）。
+
+- **`BrickField.cs`（純函式物理）**：每片 drop order `d` 的掉落距離 `dist(d)=|dest−start|`（最遠的先掉、掉最久），fall 時間 ∝ `sqrt(dist)`（自由落體），錯開成 stagger（**前一片落到定位、下一片就開始掉**，故下一片起掉時前一片還在彈）。落地後 `τ` 內阻尼彈跳 `amp·e^(−decay·τ)·|sin|`：`amp` 由**衝擊速度**（`g`＋掉落高度 `H_m` → `v=sqrt(2g·dist_m)`）× **硬度** 決定、`decay` 由**重量**決定（愈重愈快靜止）。**最後 20%（最後掉的那幾片）不彈**。整段 normalize 到 morph 窗 `[0,1]`（**`MorphSeconds` 定整體節奏**、物理參數塑形「加速度＋彈跳手感」），故 `t=1` 必全片定位＝全 B。4 方向（上下左右）：`forward=(Down||Right)` 由低座標端掉入、堆在高端；`!forward` 反之；公式統一。
+- **`BrickRenderer.cs`（Magick）**：clone A 當底，對每片 started 的木板 `Crop` B 的目的切片、`Composite` 到目前位置（掉落中可在畫面外，Magick 自動裁切；負偏移可用，比照 slide transition）。依 drop order 畫 → 正在空中的（最晚起掉）疊在已堆好的上面。
+- **設定**（`MorphSettings` 的 brick 欄位，`ToBrickParams()`）：`BrickPieces`(塊數)、`BrickDirection`(上下左右)、`BrickTotalHeightM`(高度 m)、`BrickGravity`(g)、`BrickWeight`(重量)、`BrickHardness`(硬度 0..100→0..1)。dialog 第 5 組控制項 + `cmbBrickDir`（4 方向，enum 序＝combo 序）。
+- **設計決定**：採「`MorphSeconds`＝整體掉落時長（normalize）、物理只塑形落速曲線＋彈跳」而非「物理回推絕對總長」——這樣 morph 窗語意對所有風格一致、不必停用 `轉換（秒）` 欄；`g`／高度主要透過**彈跳大小**（衝擊速度）展現（掉得高/重力大→撞擊大→彈得大），符合「重物丟下來」的手感。
+- **測試**：`BrickFieldTests`(6：末幀全定位、切片無縫鋪滿、起始第一片在畫面外其餘未起、stagger 隨時間增多起掉數、方向決定先掉哪片、IsVertical)、`MorphRainRendererTests` 加 brick 4 方向 smoke。test csproj 連結 `BrickField`(純) + `BrickRenderer`。build 0 warning、測試全綠。

--- a/docs/CreativeFeatureIdeas.md
+++ b/docs/CreativeFeatureIdeas.md
@@ -23,7 +23,7 @@
 - ✅ **微/強風吹襲（Wind Sway，風吹麥田）** — 沿風向掃過畫面的行進波 + 陣風時間漲落（Hann 包絡），視覺如風吹過麥田起伏；水波紋的方向版（平面波取代徑向波，渲染管線獨立複本）。共用 8 方向風向 + 總時間；每陣風（最多 3）各有起始/時長/強度。核爆版（dialog 模式切換、單一事件）先正向短吹→靜止→反向強風持續。GIF 同步混合（影片 15s/風 6s → 前 6s mixing + 後 9s 原片）或定格再播。
 - ✅ **通用尺寸開關（保持原始尺寸 / 不縮到 766px）** — 水波紋/風/流沙底層 math 本就尺寸無關，加 per-dialog 勾選框把它們當通用 GIF 特效用（非 Steam 前置）；大檔先估記憶體、超門檻跳警告可取消。拉霸/格網維持 766-only（語意是 5 槽位）。
 - ✅ **下雨疊層特效（Rain Overlay）**（已實機測試 OK）— 在 GIF 上疊一層半透明雨絲（overlay 合成，非位移）：雨量、風強度、風向、開始秒數、長度、雨停 fade-out + 淡出秒數；比照 wind 的 play-along / frozen-then-play 與時間窗。雨絲用種子化 hash + 畫布 wrap、DDA 畫線 alpha-blend 寫進 RGBA buffer（沿 repo 不用 Drawables 慣例）。
-- ✅ **疊圖轉換 A→B（Morph Transition）**（已實機測試 OK；4 風格）— 兩 clip 全新時間模型（先播 A → A 在窗內轉成 B、A 結束全透明消失 → 播 B 剩餘；總長 = PreRoll + Bdur）。同一 dialog 切換 4 風格：**雨滴暈染**（種子化雨滴 soft-disc coverage cross-dissolve、GlobalFloor 保證收尾全 B）、**翻轉拼圖**（近正方格、種子錯開逐格 squash 翻面、方向隨機/固定）、**聚光燈 Spotlight**（圓形探照撞球式反彈、只照處顯 B、末段擴大填滿）、**拼圖 Jigsaw**（區塊種子順序逐塊拼上顯 B、邊界線可指定色/透明、拼完淡出）。math 抽純函式單測（`RaindropRevealField`/`TileFlipGeometry`/`SpotlightField`/`JigsawGeometry`/`MorphTimeline`）。
+- ✅ **疊圖轉換 A→B（Morph Transition）**（已實機測試 OK；5 風格）— 兩 clip 全新時間模型（先播 A → A 在窗內轉成 B、A 結束全透明消失 → 播 B 剩餘；總長 = PreRoll + Bdur）。同一 dialog 切換 5 風格：**雨滴暈染**（種子化雨滴 soft-disc coverage cross-dissolve、GlobalFloor 保證收尾全 B）、**翻轉拼圖**（近正方格、種子錯開逐格 squash 翻面、方向隨機/固定）、**聚光燈 Spotlight**（圓形探照撞球式反彈、只照處顯 B、末段擴大填滿）、**拼圖 Jigsaw**（區塊種子順序逐塊拼上顯 B、邊界線可指定色/透明、拼完淡出）、**疊磚 Brick**（B 的木板由遠端一片片自由落體掉下、撞底阻尼彈跳後疊好；高度/g/重量/硬度塑形彈跳，4 方向）。math 抽純函式單測（`RaindropRevealField`/`TileFlipGeometry`/`SpotlightField`/`JigsawGeometry`/`BrickField`/`MorphTimeline`）。
 - ✅ **SIMD 評估（延後）** — 維持 `Parallel.For`；熱點（bilinear 取樣、raindrop cross-dissolve）與動手條件（`AllowUnsafeBlocks` + `System.Numerics.Vector`/`Intrinsics`、先 benchmark）記於 dev log。
 
 ---

--- a/src/Core/BrickField.cs
+++ b/src/Core/BrickField.cs
@@ -1,0 +1,140 @@
+using System;
+
+namespace GifProcessorApp
+{
+    // The direction the planks fall FROM -> the edge they stack at. Down = fall downward, stack from the
+    // bottom up (the classic case). Enum order matches the dialog's direction dropdown index.
+    public enum BrickDirection
+    {
+        Down = 0,  // fall down,  stack from the bottom
+        Up = 1,    // fall up,    stack from the top
+        Left = 2,  // fall left,  stack from the left
+        Right = 3, // fall right, stack from the right
+    }
+
+    public struct BrickParams
+    {
+        public int Pieces;          // number of planks along the fall axis
+        public BrickDirection Direction;
+        public double TotalHeightM; // physical height of the canvas (m) — scales the impact velocity
+        public double Gravity;      // g (m/s^2)
+        public double Weight;       // heavier -> the bounce settles faster
+        public double Hardness;     // 0..1 -> bigger restitution / bounce
+    }
+
+    // One plank for a single frame: it carries B's DESTINATION slice (SliceStart..+SliceLen along the fall
+    // axis) painted on a rigid board, currently drawn at CurrentPos (off-screen while waiting, accelerating
+    // while falling, at its slot +/- a damped bounce once landed).
+    public struct BrickPlank
+    {
+        public bool Started;    // false until this plank's drop begins (slice still shows clip A)
+        public int SliceStart;  // top-left coord of the destination slice along the fall axis (px in B)
+        public int SliceLen;    // px along the fall axis
+        public int CurrentPos;  // current top-left coord along the axis (may be off-canvas while falling)
+    }
+
+    // Pure, dependency-free physics for the brick/plank-drop morph (linked into the test project;
+    // BrickRenderer does the Magick crop/composite). Planks drop one at a time in a stagger derived from
+    // free-fall timing (far planks fall farther -> take longer), each landing with a damped bounce whose
+    // size comes from the impact velocity (g + drop height) and hardness, and whose settle rate comes from
+    // weight. The last 20% of planks (the final ones to drop) skip the bounce. The whole sequence is
+    // normalised to the morph window [0,1] (MorphSeconds sets the overall pace; the physics shapes the
+    // fall acceleration + bounce), so every plank is at rest -> full B by t = 1.
+    public static class BrickField
+    {
+        private const double LandEnd = 0.9;     // last plank lands at t=0.9, leaving room to settle by t=1
+        private const double SettleFrac = 0.08; // bounce/settle window (fraction of the morph) per plank
+        private const double BounceHops = 2.0;  // number of decaying hops in the bounce
+
+        public static bool IsVertical(BrickDirection d) => d == BrickDirection.Down || d == BrickDirection.Up;
+        private static bool Forward(BrickDirection d) => d == BrickDirection.Down || d == BrickDirection.Right;
+        private static int Edge(int i, int axisLen, int n) => (int)Math.Round((double)i * axisLen / n);
+
+        // All planks' states at normalised morph progress t in [0,1]. axisLen = canvas size along the fall
+        // axis (height for Down/Up, width for Left/Right).
+        public static BrickPlank[] Planks(double t, BrickParams p, int axisLen)
+        {
+            int n = p.Pieces < 1 ? 1 : p.Pieces;
+            int L = Math.Max(1, axisLen);
+            bool forward = Forward(p.Direction);
+
+            int[] edge = new int[n + 1];
+            for (int i = 0; i <= n; i++) edge[i] = Edge(i, L, n);
+
+            // Per drop-order d: which slice it fills, where it starts off-screen, how far it falls.
+            int[] sliceStart = new int[n];
+            int[] sliceLen = new int[n];
+            double[] start = new double[n];
+            double[] dest = new double[n];
+            double[] dist = new double[n];
+            for (int d = 0; d < n; d++)
+            {
+                int si = forward ? (n - 1 - d) : d; // forward stacks from the far/high end
+                sliceStart[d] = edge[si];
+                sliceLen[d] = Math.Max(1, edge[si + 1] - edge[si]);
+                dest[d] = sliceStart[d];
+                start[d] = forward ? -sliceLen[d] : L; // just off the leading edge
+                dist[d] = Math.Abs(dest[d] - start[d]);
+            }
+
+            // Normalised stagger: fall duration ~ sqrt(distance) (free fall); all land within [0, LandEnd].
+            double[] raw = new double[n];
+            double sumRaw = 0.0;
+            for (int d = 0; d < n; d++) { raw[d] = Math.Sqrt(dist[d]); sumRaw += raw[d]; }
+            double scale = sumRaw > 1e-9 ? LandEnd / sumRaw : 0.0;
+            double[] tStart = new double[n];
+            double[] tLand = new double[n];
+            double acc = 0.0;
+            for (int d = 0; d < n; d++)
+            {
+                tStart[d] = scale * acc;
+                acc += raw[d];
+                tLand[d] = scale * acc;
+            }
+
+            int noBounce = (int)Math.Ceiling(0.2 * n); // last 20% (final to drop) don't bounce
+            double hardness = p.Hardness < 0.0 ? 0.0 : p.Hardness > 1.0 ? 1.0 : p.Hardness;
+            double decay = 3.0 + Math.Max(0.0, p.Weight); // heavier -> faster settle
+
+            var planks = new BrickPlank[n];
+            for (int d = 0; d < n; d++)
+            {
+                var pl = new BrickPlank { SliceStart = sliceStart[d], SliceLen = sliceLen[d] };
+                if (t < tStart[d])
+                {
+                    pl.Started = false;
+                    pl.CurrentPos = (int)Math.Round(start[d]);
+                }
+                else
+                {
+                    pl.Started = true;
+                    if (t < tLand[d])
+                    {
+                        double frac = (t - tStart[d]) / Math.Max(1e-6, tLand[d] - tStart[d]);
+                        double pos = start[d] + (dest[d] - start[d]) * frac * frac; // accelerating fall
+                        pl.CurrentPos = (int)Math.Round(pos);
+                    }
+                    else
+                    {
+                        double pos = dest[d];
+                        double tau = t - tLand[d];
+                        bool bounces = d < n - noBounce;
+                        if (bounces && tau < SettleFrac)
+                        {
+                            double distM = dist[d] * p.TotalHeightM / L;
+                            double v = Math.Sqrt(2.0 * Math.Max(0.0, p.Gravity) * Math.Max(0.0, distM)); // impact speed
+                            double amp = hardness * sliceLen[d] * 0.6 * Math.Tanh(v / 5.0);
+                            double mag = amp * Math.Exp(-decay * tau / SettleFrac)
+                                             * Math.Abs(Math.Sin(Math.PI * BounceHops * tau / SettleFrac));
+                            double dir = forward ? 1.0 : -1.0;
+                            pos = dest[d] - dir * mag; // bounce away from the surface it hit
+                        }
+                        pl.CurrentPos = (int)Math.Round(pos);
+                    }
+                }
+                planks[d] = pl;
+            }
+            return planks;
+        }
+    }
+}

--- a/src/Core/BrickRenderer.cs
+++ b/src/Core/BrickRenderer.cs
@@ -1,0 +1,47 @@
+using System;
+using ImageMagick;
+
+namespace GifProcessorApp
+{
+    // Renders one brick/plank-drop morph frame: clip A is the base; each started plank crops its
+    // destination slice from clip B and composites it at the plank's current (falling / landed+bounce)
+    // position. Planks are drawn in drop order, so the one currently in the air (the latest to start)
+    // lands on top of the already-stacked ones. The geometry/physics is the pure BrickField.
+    public static class BrickRenderer
+    {
+        public static MagickImage RenderFrame(IMagickImage<byte> frameA, IMagickImage<byte> frameB, double t, BrickParams p)
+        {
+            int w = (int)frameA.Width;
+            int h = (int)frameA.Height;
+            bool vertical = BrickField.IsVertical(p.Direction);
+            int axisLen = vertical ? h : w;
+
+            var canvas = (MagickImage)frameA.Clone();
+            canvas.ResetPage();
+
+            BrickPlank[] planks = BrickField.Planks(t, p, axisLen);
+            for (int d = 0; d < planks.Length; d++)
+            {
+                BrickPlank pl = planks[d];
+                if (!pl.Started) continue;
+
+                using var strip = (MagickImage)frameB.Clone();
+                if (vertical)
+                {
+                    strip.Crop(new MagickGeometry(0, pl.SliceStart, (uint)w, (uint)pl.SliceLen));
+                    strip.ResetPage();
+                    canvas.Composite(strip, 0, pl.CurrentPos, CompositeOperator.Over);
+                }
+                else
+                {
+                    strip.Crop(new MagickGeometry(pl.SliceStart, 0, (uint)pl.SliceLen, (uint)h));
+                    strip.ResetPage();
+                    canvas.Composite(strip, pl.CurrentPos, 0, CompositeOperator.Over);
+                }
+            }
+
+            canvas.ResetPage();
+            return canvas;
+        }
+    }
+}

--- a/src/Core/GifProcessor.Morph.cs
+++ b/src/Core/GifProcessor.Morph.cs
@@ -187,6 +187,9 @@ namespace GifProcessorApp
             SpotlightParams spot = settings.Style == MorphStyle.Spotlight
                 ? settings.ToSpotlightParams()
                 : default;
+            BrickParams brick = settings.Style == MorphStyle.Brick
+                ? settings.ToBrickParams()
+                : default;
 
             var result = new MagickImageCollection();
             int built = 0;
@@ -225,6 +228,9 @@ namespace GifProcessorApp
                         break;
                     case MorphStyle.Jigsaw:
                         frame = JigsawRenderer.RenderFrame(aSrc[idxA], bFit[idxB], t, grid, settings);
+                        break;
+                    case MorphStyle.Brick:
+                        frame = BrickRenderer.RenderFrame(aSrc[idxA], bFit[idxB], t, brick);
                         break;
                     default:
                         frame = RaindropRevealRenderer.RenderFrame(aSrc[idxA], bFit[idxB], t, drops, settings.SoftEdge);

--- a/src/Core/MorphSettings.cs
+++ b/src/Core/MorphSettings.cs
@@ -9,6 +9,7 @@ namespace GifProcessorApp
         TileFlip = 1,       // the canvas is split into cells that flip A->B one by one
         Spotlight = 2,      // a bouncing searchlight reveals B, then expands to fill the frame
         Jigsaw = 3,         // puzzle pieces fill in A->B one by one, with fading boundary lines
+        Brick = 4,          // planks of B drop in and stack over A with an impact bounce
     }
 
     // Tile-flip squash axis / sense. Up/Down squash vertically, Left/Right horizontally; Random picks a
@@ -71,6 +72,29 @@ namespace GifProcessorApp
                 ExpandSeconds = SpotlightExpandSeconds,
                 Soft = SpotlightSoftEdge,
                 Seed = Seed,
+            };
+        }
+
+        // Brick (plank-drop) style. The overall pace is the shared MorphSeconds; these physics inputs shape
+        // the fall acceleration and the impact bounce (height + g -> impact velocity -> bounce size;
+        // hardness -> bounce amount; weight -> settle rate).
+        public int BrickPieces { get; set; } = 10;                                  // planks along the fall axis
+        public BrickDirection BrickDirection { get; set; } = BrickDirection.Down;
+        public double BrickTotalHeightM { get; set; } = 5.0;                         // canvas height in metres
+        public double BrickGravity { get; set; } = 9.8;                             // g (m/s^2)
+        public double BrickWeight { get; set; } = 1.0;                              // heavier -> settles faster
+        public double BrickHardness { get; set; } = 50.0;                           // 0..100 (%) -> bounce amount
+
+        public BrickParams ToBrickParams()
+        {
+            return new BrickParams
+            {
+                Pieces = BrickPieces,
+                Direction = BrickDirection,
+                TotalHeightM = BrickTotalHeightM,
+                Gravity = BrickGravity,
+                Weight = BrickWeight,
+                Hardness = BrickHardness / 100.0,
             };
         }
     }

--- a/src/Dialogs/MorphTransitionDialog.cs
+++ b/src/Dialogs/MorphTransitionDialog.cs
@@ -67,10 +67,25 @@ namespace GifProcessorApp
         private Panel pnlJigsawColor = null!;
         private Color _jigsawLineColor = Color.White;
 
+        // Brick group.
+        private Label lblBrickPieces = null!;
+        private NumericUpDown numBrickPieces = null!;
+        private Label lblBrickDir = null!;
+        private ComboBox cmbBrickDir = null!;
+        private Label lblBrickHeight = null!;
+        private NumericUpDown numBrickHeight = null!;
+        private Label lblBrickG = null!;
+        private NumericUpDown numBrickG = null!;
+        private Label lblBrickWeight = null!;
+        private NumericUpDown numBrickWeight = null!;
+        private Label lblBrickHardness = null!;
+        private NumericUpDown numBrickHardness = null!;
+
         private readonly List<Control> _raindropControls = new List<Control>();
         private readonly List<Control> _tileControls = new List<Control>();
         private readonly List<Control> _spotlightControls = new List<Control>();
         private readonly List<Control> _jigsawControls = new List<Control>();
+        private readonly List<Control> _brickControls = new List<Control>();
 
         private Button btnOK = null!;
         private Button btnCancel = null!;
@@ -114,6 +129,12 @@ namespace GifProcessorApp
                 JigsawLineR = _jigsawLineColor.R,
                 JigsawLineG = _jigsawLineColor.G,
                 JigsawLineB = _jigsawLineColor.B,
+                BrickPieces = (int)numBrickPieces.Value,
+                BrickDirection = (BrickDirection)cmbBrickDir.SelectedIndex,
+                BrickTotalHeightM = (double)numBrickHeight.Value,
+                BrickGravity = (double)numBrickG.Value,
+                BrickWeight = (double)numBrickWeight.Value,
+                BrickHardness = (double)numBrickHardness.Value,
             };
         }
 
@@ -124,6 +145,7 @@ namespace GifProcessorApp
             foreach (var c in _tileControls) c.Visible = style == MorphStyle.TileFlip;
             foreach (var c in _spotlightControls) c.Visible = style == MorphStyle.Spotlight;
             foreach (var c in _jigsawControls) c.Visible = style == MorphStyle.Jigsaw;
+            foreach (var c in _brickControls) c.Visible = style == MorphStyle.Brick;
         }
 
         private void RefreshJigsawColorEnabled()
@@ -166,6 +188,12 @@ namespace GifProcessorApp
             lblJigsawPieces.Text = Resources.MorphDialog_JigsawPieces;
             chkJigsawLines.Text = Resources.MorphDialog_JigsawShowLines;
             lblJigsawColor.Text = Resources.MorphDialog_JigsawLineColor;
+            lblBrickPieces.Text = Resources.MorphDialog_BrickPieces;
+            lblBrickDir.Text = Resources.MorphDialog_BrickDir;
+            lblBrickHeight.Text = Resources.MorphDialog_BrickHeight;
+            lblBrickG.Text = Resources.MorphDialog_BrickGravity;
+            lblBrickWeight.Text = Resources.MorphDialog_BrickWeight;
+            lblBrickHardness.Text = Resources.MorphDialog_BrickHardness;
             btnBrowseA.Text = Resources.Button_Browse;
             btnBrowseB.Text = Resources.Button_Browse;
             btnBrowseOutput.Text = Resources.Button_Browse;
@@ -178,6 +206,7 @@ namespace GifProcessorApp
             cmbStyle.Items.Add(Resources.MorphStyle_TileFlip);
             cmbStyle.Items.Add(Resources.MorphStyle_Spotlight);
             cmbStyle.Items.Add(Resources.MorphStyle_Jigsaw);
+            cmbStyle.Items.Add(Resources.MorphStyle_Brick);
             cmbStyle.SelectedIndex = styleSel;
 
             int dirSel = cmbFlipDir.SelectedIndex < 0 ? 0 : cmbFlipDir.SelectedIndex;
@@ -188,6 +217,14 @@ namespace GifProcessorApp
             cmbFlipDir.Items.Add(Resources.FlipDir_Left);
             cmbFlipDir.Items.Add(Resources.FlipDir_Right);
             cmbFlipDir.SelectedIndex = dirSel;
+
+            int brickDirSel = cmbBrickDir.SelectedIndex < 0 ? 0 : cmbBrickDir.SelectedIndex;
+            cmbBrickDir.Items.Clear();
+            cmbBrickDir.Items.Add(Resources.BrickDir_Down);
+            cmbBrickDir.Items.Add(Resources.BrickDir_Up);
+            cmbBrickDir.Items.Add(Resources.BrickDir_Left);
+            cmbBrickDir.Items.Add(Resources.BrickDir_Right);
+            cmbBrickDir.SelectedIndex = brickDirSel;
         }
 
         private void ApplyTheme()
@@ -431,6 +468,21 @@ namespace GifProcessorApp
             pnlJigsawColor = new Panel { Location = new Point(272, 265), Size = new Size(44, 22), BorderStyle = BorderStyle.FixedSingle, BackColor = _jigsawLineColor, Cursor = Cursors.Hand };
             pnlJigsawColor.Click += PnlJigsawColor_Click;
 
+            // --- Brick group (same vertical band; the shared "Morph (s)" sets the overall pace, these
+            //     physics inputs shape the fall acceleration + impact bounce) ---
+            lblBrickPieces = new Label { Location = new Point(14, 234), Size = new Size(46, 20), Text = "Pieces" };
+            numBrickPieces = MakeNum(62, 232, 46, 0, 2m, 30m, 1m, 10m);
+            lblBrickDir = new Label { Location = new Point(116, 234), Size = new Size(40, 20), Text = "Dir" };
+            cmbBrickDir = new ComboBox { Location = new Point(158, 232), Size = new Size(96, 23), DropDownStyle = ComboBoxStyle.DropDownList };
+            lblBrickHeight = new Label { Location = new Point(262, 234), Size = new Size(58, 20), Text = "Height m" };
+            numBrickHeight = MakeNum(322, 232, 56, 1, 0.5m, 50.0m, 0.5m, 5.0m);
+            lblBrickG = new Label { Location = new Point(14, 267), Size = new Size(18, 20), Text = "g" };
+            numBrickG = MakeNum(36, 265, 56, 1, 1.0m, 30.0m, 0.1m, 9.8m);
+            lblBrickWeight = new Label { Location = new Point(100, 267), Size = new Size(46, 20), Text = "Weight" };
+            numBrickWeight = MakeNum(150, 265, 56, 1, 0.1m, 20.0m, 0.1m, 1.0m);
+            lblBrickHardness = new Label { Location = new Point(214, 267), Size = new Size(58, 20), Text = "Hardness" };
+            numBrickHardness = MakeNum(276, 265, 56, 0, 0m, 100m, 5m, 50m);
+
             btnOK = new Button { Location = new Point(363, 312), Size = new Size(75, 25), Text = "OK", UseVisualStyleBackColor = true };
             btnOK.Click += BtnOK_Click;
             btnCancel = new Button { Location = new Point(444, 312), Size = new Size(82, 25), Text = "Cancel", DialogResult = DialogResult.Cancel, UseVisualStyleBackColor = true };
@@ -448,6 +500,11 @@ namespace GifProcessorApp
             _jigsawControls.AddRange(new Control[]
             {
                 lblJigsawPieces, numJigsawPieces, chkJigsawLines, lblJigsawColor, pnlJigsawColor,
+            });
+            _brickControls.AddRange(new Control[]
+            {
+                lblBrickPieces, numBrickPieces, lblBrickDir, cmbBrickDir, lblBrickHeight, numBrickHeight,
+                lblBrickG, numBrickG, lblBrickWeight, numBrickWeight, lblBrickHardness, numBrickHardness,
             });
 
             SuspendLayout();
@@ -473,6 +530,7 @@ namespace GifProcessorApp
             foreach (var c in _tileControls) Controls.Add(c);
             foreach (var c in _spotlightControls) Controls.Add(c);
             foreach (var c in _jigsawControls) Controls.Add(c);
+            foreach (var c in _brickControls) Controls.Add(c);
             Controls.Add(btnOK);
             Controls.Add(btnCancel);
 


### PR DESCRIPTION
## Summary
Fifth style for the **A→B morph transition** (`Style` dropdown now has 5). Field-tested OK.

- **Brick drop 🧱**: the canvas is split into N planks along the fall axis; clip A keeps playing while B's planks drop in one by one and stack up. Free-fall stagger (far planks fall farther → take longer), each lands with a damped impact bounce, the airborne plank lands on top. Each plank carries B's **destination** slice (fixed content while falling, matching the spec). The last 20% of planks skip the bounce. All planks at rest → full B at t=1.
- Settings: pieces, direction (down/up/left/right), height (m), g, weight, hardness.

## Implementation
- `BrickField` (pure physics: sqrt-distance fall times, staggered schedule, accelerating fall, damped bounce sized by impact velocity × hardness and settled by weight; 4 directions unified) + `BrickRenderer` (crop B slice, composite at the falling/bounce position over A).
- `MorphStyle.Brick` + settings, engine dispatch, dialog brick group + direction combo; 11 localized strings (en/zh-TW/ja + Designer).
- **Design note:** `MorphSeconds` sets the overall drop pace; the physics inputs shape the fall acceleration and the impact bounce (so g/height mainly affect bounce size), keeping morph-window semantics uniform across all 5 styles.

## Testing
- `dotnet build SteamGifCropper.sln` → 0 warnings / 0 errors.
- Full xUnit suite: **248 tests, 0 failures** (`BrickFieldTests` + brick renderer smoke across 4 directions).
- User field-tested in the app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)