### PR TITLE
feat(water): water-fill + bubbles effect (main UI + A-to-B morph style)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,18 +120,20 @@ Each dialog handles one specific operation type:
 - `RippleDropPickerForm` - Click-to-pick a ripple drop position on frame 0
 - `WindDialog` - Wind sway (風吹麥田): travelling-wave displacement, normal/nuclear modes (image / GIF)
 - `RainDialog` - Rain overlay: translucent slanted streaks, wind + "rain stops" fade-out (image / GIF)
-- `MorphTransitionDialog` - A→B morph transition (raindrop reveal / tile flip / spotlight / jigsaw / brick drop) with a pre-roll + remaining-B timeline
+- `WaterDialog` - Water fill: rising water with refraction + multi-layer lensing bubbles (image / GIF)
+- `MorphTransitionDialog` - A→B morph transition (raindrop reveal / tile flip / spotlight / jigsaw / brick drop / water fill) with a pre-roll + remaining-B timeline
 
 > **Creative-effects detail:** these "766px single-output, chainable" effects (grid mosaic, slot
-> machine, quicksand, ripple, wind, rain, A→B morph) — their ideas and completion status live in
+> machine, quicksand, ripple, wind, rain, water fill, A→B morph) — their ideas and completion status live in
 > `docs/CreativeFeatureIdeas.md`; the detailed implementation/handoff dev log (file lists, commits,
 > semantics, gotchas) lives in `docs/CreativeEffectsDevLog.md`.
 > Their math is extracted into pure, dependency-free files for unit testing — `SlotMachineGeometry.cs`,
 > `QuicksandGeometry.cs`, `GifEffectWindow.cs`, `GridMosaicGeometry.cs`, `RippleField.cs`,
 > `WindField.cs`, `RainField.cs`, `RaindropRevealField.cs`, `TileFlipGeometry.cs`, `SpotlightField.cs`,
-> `JigsawGeometry.cs`, `BrickField.cs`, `MorphSettings.cs` (`MorphTimeline`) (+ the Magick-side
-> `RippleRenderer.cs`, `GridMosaicRenderer.cs`, `RaindropRevealRenderer.cs`, `TileFlipRenderer.cs`,
-> `SpotlightRenderer.cs`, `JigsawRenderer.cs`, `BrickRenderer.cs`) — linked into the test project (pure files only).
+> `JigsawGeometry.cs`, `BrickField.cs`, `WaterField.cs`, `MorphSettings.cs` (`MorphTimeline`) (+ the
+> Magick-side `RippleRenderer.cs`, `GridMosaicRenderer.cs`, `RaindropRevealRenderer.cs`,
+> `TileFlipRenderer.cs`, `SpotlightRenderer.cs`, `JigsawRenderer.cs`, `BrickRenderer.cs`,
+> `WaterRenderer.cs`) — linked into the test project (pure files only).
 > The A→B morph uses its own `pre-roll + morph window + remaining-B` timeline (total = pre-roll + B
 > duration), distinct from the concat overlap model; it lives in `GifProcessor.Morph.cs` /
 > `MorphTransitionDialog`, not in `TransitionGenerator`.
@@ -329,6 +331,7 @@ SteamGifCropper/
 │   │   ├── RippleSettings/Field/Renderer.cs          # Water ripple (Field pure, Renderer Magick)
 │   │   ├── WindSettings/Field/Renderer.cs            # Wind sway (Field pure, Renderer Magick)
 │   │   ├── RainSettings/Field/Renderer.cs            # Rain overlay (Field pure, Renderer draws streaks into RGBA buffer)
+│   │   ├── WaterSettings/Field/Renderer.cs           # Water fill + bubbles (Field pure, Renderer above/below sampler)
 │   │   ├── MorphSettings.cs                          # A→B morph settings + MorphTimeline (pure)
 │   │   ├── RaindropRevealField/Renderer.cs           # Morph raindrop reveal (Field pure, Renderer Magick)
 │   │   ├── TileFlipGeometry/Renderer.cs              # Morph tile flip (Geometry pure, Renderer Magick)
@@ -355,7 +358,8 @@ SteamGifCropper/
 │   │   ├── RippleDropPickerForm.cs         # Click-to-pick ripple drop position
 │   │   ├── WindDialog.cs
 │   │   ├── RainDialog.cs                   # Rain overlay (translucent streaks)
-│   │   └── MorphTransitionDialog.cs        # A→B morph (raindrop reveal / tile flip)
+│   │   ├── WaterDialog.cs                  # Water fill + bubbles
+│   │   └── MorphTransitionDialog.cs        # A→B morph (raindrop / tile flip / spotlight / jigsaw / brick / water)
 │   └── Platform/                           # Windows integration
 │       ├── WindowsThemeManager.cs
 │       └── RegistryProvider.cs

--- a/Properties/Resources.Designer.cs
+++ b/Properties/Resources.Designer.cs
@@ -2633,6 +2633,120 @@ namespace SteamGifCropper.Properties {
             }
         }
 
+        internal static string Status_WaterBuilding {
+            get {
+                return ResourceManager.GetString("Status_WaterBuilding", resourceCulture);
+            }
+        }
+
+        internal static string Button_WaterStatic {
+            get {
+                return ResourceManager.GetString("Button_WaterStatic", resourceCulture);
+            }
+        }
+
+        internal static string Button_WaterGif {
+            get {
+                return ResourceManager.GetString("Button_WaterGif", resourceCulture);
+            }
+        }
+
+        internal static string WaterDialog_Title {
+            get {
+                return ResourceManager.GetString("WaterDialog_Title", resourceCulture);
+            }
+        }
+
+        internal static string WaterDialog_Direction {
+            get {
+                return ResourceManager.GetString("WaterDialog_Direction", resourceCulture);
+            }
+        }
+
+        internal static string WaterDialog_FullSeconds {
+            get {
+                return ResourceManager.GetString("WaterDialog_FullSeconds", resourceCulture);
+            }
+        }
+
+        internal static string WaterDialog_Refraction {
+            get {
+                return ResourceManager.GetString("WaterDialog_Refraction", resourceCulture);
+            }
+        }
+
+        internal static string WaterDialog_Wobble {
+            get {
+                return ResourceManager.GetString("WaterDialog_Wobble", resourceCulture);
+            }
+        }
+
+        internal static string WaterDialog_BubbleCount {
+            get {
+                return ResourceManager.GetString("WaterDialog_BubbleCount", resourceCulture);
+            }
+        }
+
+        internal static string WaterDialog_BubbleSize {
+            get {
+                return ResourceManager.GetString("WaterDialog_BubbleSize", resourceCulture);
+            }
+        }
+
+        internal static string WaterDialog_Layers {
+            get {
+                return ResourceManager.GetString("WaterDialog_Layers", resourceCulture);
+            }
+        }
+
+        internal static string WaterDialog_FadeOut {
+            get {
+                return ResourceManager.GetString("WaterDialog_FadeOut", resourceCulture);
+            }
+        }
+
+        internal static string WaterDir_Up {
+            get {
+                return ResourceManager.GetString("WaterDir_Up", resourceCulture);
+            }
+        }
+
+        internal static string WaterDir_Down {
+            get {
+                return ResourceManager.GetString("WaterDir_Down", resourceCulture);
+            }
+        }
+
+        internal static string WaterDir_Left {
+            get {
+                return ResourceManager.GetString("WaterDir_Left", resourceCulture);
+            }
+        }
+
+        internal static string WaterDir_Right {
+            get {
+                return ResourceManager.GetString("WaterDir_Right", resourceCulture);
+            }
+        }
+
+        internal static string WaterDialog_GifPlayDuring {
+            get {
+                return ResourceManager.GetString("WaterDialog_GifPlayDuring", resourceCulture);
+            }
+        }
+
+        internal static string WaterDialog_GifFreeze {
+            get {
+                return ResourceManager.GetString("WaterDialog_GifFreeze", resourceCulture);
+            }
+        }
+
+        internal static string MorphStyle_Water {
+            get {
+                return ResourceManager.GetString("MorphStyle_Water", resourceCulture);
+            }
+        }
+
         internal static string MorphDialog_SpotRadius {
             get {
                 return ResourceManager.GetString("MorphDialog_SpotRadius", resourceCulture);

--- a/Properties/Resources.ja.resx
+++ b/Properties/Resources.ja.resx
@@ -1411,6 +1411,63 @@ FFmpeg 出力（切り捨て）:
   <data name="BrickDir_Right" xml:space="preserve">
     <value>右</value>
   </data>
+  <data name="Status_WaterBuilding" xml:space="preserve">
+    <value>水満たしを生成中…</value>
+  </data>
+  <data name="Button_WaterStatic" xml:space="preserve">
+    <value>水満たし（画像）</value>
+  </data>
+  <data name="Button_WaterGif" xml:space="preserve">
+    <value>水満たし（GIF）</value>
+  </data>
+  <data name="WaterDialog_Title" xml:space="preserve">
+    <value>水満たし</value>
+  </data>
+  <data name="WaterDialog_Direction" xml:space="preserve">
+    <value>方向</value>
+  </data>
+  <data name="WaterDialog_FullSeconds" xml:space="preserve">
+    <value>満水（秒）</value>
+  </data>
+  <data name="WaterDialog_Refraction" xml:space="preserve">
+    <value>屈折</value>
+  </data>
+  <data name="WaterDialog_Wobble" xml:space="preserve">
+    <value>水面の揺れ</value>
+  </data>
+  <data name="WaterDialog_BubbleCount" xml:space="preserve">
+    <value>泡の数</value>
+  </data>
+  <data name="WaterDialog_BubbleSize" xml:space="preserve">
+    <value>泡の大きさ</value>
+  </data>
+  <data name="WaterDialog_Layers" xml:space="preserve">
+    <value>層数</value>
+  </data>
+  <data name="WaterDialog_FadeOut" xml:space="preserve">
+    <value>フェードアウト（秒）</value>
+  </data>
+  <data name="WaterDir_Up" xml:space="preserve">
+    <value>上</value>
+  </data>
+  <data name="WaterDir_Down" xml:space="preserve">
+    <value>下</value>
+  </data>
+  <data name="WaterDir_Left" xml:space="preserve">
+    <value>左</value>
+  </data>
+  <data name="WaterDir_Right" xml:space="preserve">
+    <value>右</value>
+  </data>
+  <data name="WaterDialog_GifPlayDuring" xml:space="preserve">
+    <value>再生に水を重ねる</value>
+  </data>
+  <data name="WaterDialog_GifFreeze" xml:space="preserve">
+    <value>最初のフレームで固定</value>
+  </data>
+  <data name="MorphStyle_Water" xml:space="preserve">
+    <value>水満たし</value>
+  </data>
   <data name="MorphDialog_SpotRadius" xml:space="preserve">
     <value>光の大きさ</value>
   </data>

--- a/Properties/Resources.resx
+++ b/Properties/Resources.resx
@@ -1410,6 +1410,63 @@ Technical details: {5}</value>
   <data name="BrickDir_Right" xml:space="preserve">
     <value>Right</value>
   </data>
+  <data name="Status_WaterBuilding" xml:space="preserve">
+    <value>Building water fill...</value>
+  </data>
+  <data name="Button_WaterStatic" xml:space="preserve">
+    <value>Water Fill (Image)</value>
+  </data>
+  <data name="Button_WaterGif" xml:space="preserve">
+    <value>Water Fill (GIF)</value>
+  </data>
+  <data name="WaterDialog_Title" xml:space="preserve">
+    <value>Water Fill</value>
+  </data>
+  <data name="WaterDialog_Direction" xml:space="preserve">
+    <value>Dir</value>
+  </data>
+  <data name="WaterDialog_FullSeconds" xml:space="preserve">
+    <value>Full level</value>
+  </data>
+  <data name="WaterDialog_Refraction" xml:space="preserve">
+    <value>Refract</value>
+  </data>
+  <data name="WaterDialog_Wobble" xml:space="preserve">
+    <value>Wobble</value>
+  </data>
+  <data name="WaterDialog_BubbleCount" xml:space="preserve">
+    <value>Bubbles</value>
+  </data>
+  <data name="WaterDialog_BubbleSize" xml:space="preserve">
+    <value>Size</value>
+  </data>
+  <data name="WaterDialog_Layers" xml:space="preserve">
+    <value>Layers</value>
+  </data>
+  <data name="WaterDialog_FadeOut" xml:space="preserve">
+    <value>Fade out (s)</value>
+  </data>
+  <data name="WaterDir_Up" xml:space="preserve">
+    <value>Up</value>
+  </data>
+  <data name="WaterDir_Down" xml:space="preserve">
+    <value>Down</value>
+  </data>
+  <data name="WaterDir_Left" xml:space="preserve">
+    <value>Left</value>
+  </data>
+  <data name="WaterDir_Right" xml:space="preserve">
+    <value>Right</value>
+  </data>
+  <data name="WaterDialog_GifPlayDuring" xml:space="preserve">
+    <value>Fill over playback</value>
+  </data>
+  <data name="WaterDialog_GifFreeze" xml:space="preserve">
+    <value>Freeze on frame 0</value>
+  </data>
+  <data name="MorphStyle_Water" xml:space="preserve">
+    <value>Water fill</value>
+  </data>
   <data name="MorphDialog_SpotRadius" xml:space="preserve">
     <value>Light size</value>
   </data>

--- a/Properties/Resources.zh-TW.resx
+++ b/Properties/Resources.zh-TW.resx
@@ -1411,6 +1411,63 @@ FFmpeg 輸出 (部分)：
   <data name="BrickDir_Right" xml:space="preserve">
     <value>向右</value>
   </data>
+  <data name="Status_WaterBuilding" xml:space="preserve">
+    <value>正在產生灌水特效…</value>
+  </data>
+  <data name="Button_WaterStatic" xml:space="preserve">
+    <value>灌水特效（圖片）</value>
+  </data>
+  <data name="Button_WaterGif" xml:space="preserve">
+    <value>灌水特效（GIF）</value>
+  </data>
+  <data name="WaterDialog_Title" xml:space="preserve">
+    <value>灌水特效</value>
+  </data>
+  <data name="WaterDialog_Direction" xml:space="preserve">
+    <value>方向</value>
+  </data>
+  <data name="WaterDialog_FullSeconds" xml:space="preserve">
+    <value>滿水位（秒）</value>
+  </data>
+  <data name="WaterDialog_Refraction" xml:space="preserve">
+    <value>折射</value>
+  </data>
+  <data name="WaterDialog_Wobble" xml:space="preserve">
+    <value>水面搖動</value>
+  </data>
+  <data name="WaterDialog_BubbleCount" xml:space="preserve">
+    <value>泡泡數</value>
+  </data>
+  <data name="WaterDialog_BubbleSize" xml:space="preserve">
+    <value>泡泡大小</value>
+  </data>
+  <data name="WaterDialog_Layers" xml:space="preserve">
+    <value>層數</value>
+  </data>
+  <data name="WaterDialog_FadeOut" xml:space="preserve">
+    <value>淡出（秒）</value>
+  </data>
+  <data name="WaterDir_Up" xml:space="preserve">
+    <value>向上</value>
+  </data>
+  <data name="WaterDir_Down" xml:space="preserve">
+    <value>向下</value>
+  </data>
+  <data name="WaterDir_Left" xml:space="preserve">
+    <value>向左</value>
+  </data>
+  <data name="WaterDir_Right" xml:space="preserve">
+    <value>向右</value>
+  </data>
+  <data name="WaterDialog_GifPlayDuring" xml:space="preserve">
+    <value>灌水疊在播放上</value>
+  </data>
+  <data name="WaterDialog_GifFreeze" xml:space="preserve">
+    <value>定格第一幀</value>
+  </data>
+  <data name="MorphStyle_Water" xml:space="preserve">
+    <value>灌水</value>
+  </data>
   <data name="MorphDialog_SpotRadius" xml:space="preserve">
     <value>光圈大小</value>
   </data>

--- a/SteamGifCropper.Tests/MorphRainRendererTests.cs
+++ b/SteamGifCropper.Tests/MorphRainRendererTests.cs
@@ -139,4 +139,18 @@ public class MorphRainRendererTests
         Assert.Equal(80u, outImg.Width);
         Assert.Equal(50u, outImg.Height);
     }
+
+    [Theory]
+    [InlineData(0.0)]
+    [InlineData(0.5)]
+    [InlineData(1.0)]
+    public void WaterRenderer_PreservesDimensions(double fill)
+    {
+        using var a = new MagickImage(MagickColors.Red, 64, 48);
+        using var b = new MagickImage(MagickColors.Blue, 64, 48);
+        var p = new WaterParams { Direction = WaterDirection.Up, RefractionStrength = 4, SurfaceWobble = 6, BubbleSize = 10, Layers = 3, Seed = 3 };
+        using var outImg = WaterRenderer.RenderFrame(a, b, fill, 1.2, p, 0.7);
+        Assert.Equal(64u, outImg.Width);
+        Assert.Equal(48u, outImg.Height);
+    }
 }

--- a/SteamGifCropper.Tests/SteamGifCropper.Tests.csproj
+++ b/SteamGifCropper.Tests/SteamGifCropper.Tests.csproj
@@ -63,6 +63,8 @@
     <Compile Include="..\src\Core\JigsawRenderer.cs" Link="JigsawRenderer.cs" />
     <Compile Include="..\src\Core\BrickField.cs" Link="BrickField.cs" />
     <Compile Include="..\src\Core\BrickRenderer.cs" Link="BrickRenderer.cs" />
+    <Compile Include="..\src\Core\WaterField.cs" Link="WaterField.cs" />
+    <Compile Include="..\src\Core\WaterRenderer.cs" Link="WaterRenderer.cs" />
     <Compile Include="..\src\Core\GridMosaicSettings.cs" Link="GridMosaicSettings.cs" />
     <Compile Include="..\src\Core\GridMosaicRenderer.cs" Link="GridMosaicRenderer.cs" />
     <Compile Include="..\src\Core\GifConcatenationSettings.cs" Link="GifConcatenationSettings.cs" />

--- a/SteamGifCropper.Tests/WaterFieldTests.cs
+++ b/SteamGifCropper.Tests/WaterFieldTests.cs
@@ -1,0 +1,90 @@
+using System;
+using GifProcessorApp;
+
+namespace SteamGifCropper.Tests;
+
+public class WaterFieldTests
+{
+    private static WaterParams Params(WaterDirection dir = WaterDirection.Up) => new WaterParams
+    {
+        Direction = dir,
+        RefractionStrength = 4,
+        SurfaceWobble = 0, // flat surface so the underwater checks are deterministic
+        BubbleSize = 12,
+        Layers = 3,
+        Seed = 5,
+    };
+
+    [Fact]
+    public void FillFrac_RampsFromStartToFull_ThenStaysFull()
+    {
+        Assert.Equal(0.0, WaterField.FillFrac(0.0, 1.0, 4.0), 6);
+        Assert.Equal(0.0, WaterField.FillFrac(1.0, 1.0, 4.0), 6);
+        Assert.Equal(0.5, WaterField.FillFrac(2.5, 1.0, 4.0), 6);
+        Assert.Equal(1.0, WaterField.FillFrac(4.0, 1.0, 4.0), 6);
+        Assert.Equal(1.0, WaterField.FillFrac(9.0, 1.0, 4.0), 6); // stays full afterwards
+    }
+
+    [Fact]
+    public void IsUnderwater_Up_BottomSubmergesFirst()
+    {
+        var p = Params(WaterDirection.Up);
+        // Half full: the bottom of a 100-tall canvas is underwater, the top is not.
+        Assert.True(WaterField.IsUnderwater(50, 90, 1.0, 0.5, 100, 100, p));
+        Assert.False(WaterField.IsUnderwater(50, 10, 1.0, 0.5, 100, 100, p));
+        // Empty -> nothing submerged; full -> everything submerged.
+        Assert.False(WaterField.IsUnderwater(50, 90, 1.0, 0.0, 100, 100, p));
+        Assert.True(WaterField.IsUnderwater(50, 10, 1.0, 1.0, 100, 100, p));
+    }
+
+    [Fact]
+    public void IsUnderwater_Down_TopSubmergesFirst()
+    {
+        var p = Params(WaterDirection.Down);
+        Assert.True(WaterField.IsUnderwater(50, 10, 1.0, 0.5, 100, 100, p));
+        Assert.False(WaterField.IsUnderwater(50, 90, 1.0, 0.5, 100, 100, p));
+    }
+
+    [Fact]
+    public void Bubbles_AllUnderwater_AndCountAuto()
+    {
+        var p = Params();
+        var bubbles = WaterField.Bubbles(0.7, 0.6, 200, 200, p);
+        // Count is automatic; surface-fading may cull some, so the result never exceeds the auto count.
+        Assert.True(bubbles.Length <= WaterField.AutoBubbleCount(200, 200));
+        foreach (var b in bubbles)
+        {
+            Assert.True(WaterField.IsUnderwater((int)b.X, (int)b.Y, 0.7, 0.6, 200, 200, p));
+            Assert.True(b.R >= 1.0);
+        }
+        // No water -> no bubbles.
+        Assert.Empty(WaterField.Bubbles(0.7, 0.0, 200, 200, p));
+    }
+
+    [Fact]
+    public void AutoBubbleCount_IsBounded()
+    {
+        Assert.InRange(WaterField.AutoBubbleCount(766, 400), 4, 20);
+        Assert.InRange(WaterField.AutoBubbleCount(10, 10), 4, 20);
+        Assert.InRange(WaterField.AutoBubbleCount(4000, 4000), 4, 20);
+    }
+
+    [Fact]
+    public void EffectAlpha_FullThenFadesAfterFull()
+    {
+        Assert.Equal(1.0, WaterField.EffectAlpha(3.0, 4.0, 0.5), 6);  // before full
+        Assert.Equal(1.0, WaterField.EffectAlpha(4.0, 4.0, 0.5), 6);  // at full
+        Assert.Equal(0.5, WaterField.EffectAlpha(4.25, 4.0, 0.5), 6); // halfway through the fade
+        Assert.Equal(0.0, WaterField.EffectAlpha(4.5, 4.0, 0.5), 6);  // fully faded out
+        Assert.Equal(0.0, WaterField.EffectAlpha(9.0, 4.0, 0.5), 6);  // stays gone
+        Assert.Equal(1.0, WaterField.EffectAlpha(9.0, 4.0, 0.0), 6);  // fade 0 -> never fades
+    }
+
+    [Fact]
+    public void LensFactor_MagnifiesInside_NeutralAtRim()
+    {
+        Assert.True(WaterField.LensFactor(0.0, 20.0, 0.6) < 1.0);  // centre magnifies
+        Assert.Equal(1.0, WaterField.LensFactor(20.0, 20.0, 0.6), 6); // at the rim
+        Assert.Equal(1.0, WaterField.LensFactor(30.0, 20.0, 0.6), 6); // outside
+    }
+}

--- a/docs/CreativeEffectsDevLog.md
+++ b/docs/CreativeEffectsDevLog.md
@@ -282,3 +282,22 @@
 - **設定**（`MorphSettings` 的 brick 欄位，`ToBrickParams()`）：`BrickPieces`(塊數)、`BrickDirection`(上下左右)、`BrickTotalHeightM`(高度 m)、`BrickGravity`(g)、`BrickWeight`(重量)、`BrickHardness`(硬度 0..100→0..1)。dialog 第 5 組控制項 + `cmbBrickDir`（4 方向，enum 序＝combo 序）。
 - **設計決定**：採「`MorphSeconds`＝整體掉落時長（normalize）、物理只塑形落速曲線＋彈跳」而非「物理回推絕對總長」——這樣 morph 窗語意對所有風格一致、不必停用 `轉換（秒）` 欄；`g`／高度主要透過**彈跳大小**（衝擊速度）展現（掉得高/重力大→撞擊大→彈得大），符合「重物丟下來」的手感。
 - **測試**：`BrickFieldTests`(6：末幀全定位、切片無縫鋪滿、起始第一片在畫面外其餘未起、stagger 隨時間增多起掉數、方向決定先掉哪片、IsVertical)、`MorphRainRendererTests` 加 brick 4 方向 smoke。test csproj 連結 `BrickField`(純) + `BrickRenderer`。build 0 warning、測試全綠。
+
+## 灌滿水 + 水中氣泡（Water Fill）— 主UI 特效 + 疊圖轉換風格（共用 core）
+
+水由某方向**逐漸灌滿**畫布；水面下＝來源經**折射扭曲**＋透過**上升氣泡（透鏡）**看到的影像，水面上＝原樣不變；水面是**會搖動的波浪線**。氣泡分 **≥3 個遠近層**（自動近大快強／遠小慢弱）、升到水面就**移出**。同一套 core 同時服務「單一 GIF 特效」與「A→B 疊圖轉換」——差別只在水面下看到誰。
+
+- **`WaterField.cs`（純函式）**：`FillFrac(te,start,full)`（0→1，滿後維持）；`Surface(perp,te,fill,...)` 波浪＋搖動水面線（兩端 fade 成平）；`IsUnderwater`（4 方向：Up 由下淹、Down 由上、Left 由左、Right 由右；`fromLow=Down||Left`）；`Shimmer`（水面下正弦折射位移）；`Bubbles`（種子化、每顆 layer→深度→大小/速度/不透明/透鏡強度，沿軸朝水面移動、過水面即不畫＝移出，wrap 重生）；`LensFactor`（圓內放大、邊緣回 1）。
+- **`WaterRenderer.cs`（Magick）**：參數化 `aboveSrc`/`belowSrc`（單一 GIF 兩者同幀；morph above=A、below=B）。Pass 1 逐像素：水面上＝aboveSrc 原樣、水面下＝belowSrc 加 shimmer 雙線性取樣。Pass 2 逐氣泡（依半徑排序，近大後畫）：bbox 內 lens 重取樣 belowSrc（朝泡心放大）＋亮邊 rim＋左上 specular highlight。皆寫進 RGBA buffer。
+- **主UI 特效**（`WaterSettings`/`GifProcessor.Water.cs`/`WaterDialog`，比照 wind/rain）：play-along＝水在 `[Start,Full]` 窗內淹過 live 幀、滿後維持（其餘片段**全淹沒折射**播完＝符合不截斷不變式、輸出＝GIF 全長）；frozen-then-play＝定格 frame0 淹滿 `Duration` 秒、再播完整 GIF（全淹沒）。主視窗 `btnWaterStatic`/`btnWaterGif`（第 14 列 y=379；morph 鈕下移到 410、下方元件 +31、`ClientSize` 680→**711**）。
+- **疊圖轉換風格**（`MorphStyle.WaterFill`，第 6 種）：`fill = morph 進度 t`（窗內由 0 淹到 1→全 B）、`te = k/fps`（氣泡動畫時間）；above=A、below=B。dialog 第 6 組控制項（方向/折射/水面搖動/泡泡數/泡泡大小/層數，`cmbWaterDir`）。
+- **設定**：方向、`StartSeconds`/`FullSeconds`（主UI）、折射強度、水面搖動、泡泡數、泡泡大小、層數（≥3）。
+- **效能**：Pass 1 = O(W·H)；Pass 2 = O(Σ 泡泡 bbox)（有界，泡泡 lens 只在自己 bbox 內重取樣，避免逐像素掃所有泡泡）。
+- **設計取捨／待調**：morph 在 `t=1` 整面是「折射的 B」，下一段 phase 3 是「原樣 B」，理論上有一格輕微跳變（折射僅數 px、gentle，可調小折射或日後在末段淡出折射）。氣泡視覺（rim/highlight/lens 強度）為起始猜測、待實機調校。
+- **測試**：`WaterFieldTests`(7：FillFrac 斜坡+維持、Up/Down 淹沒方向、泡泡皆在水下且自動數、AutoBubbleCount 範圍、EffectAlpha 滿後淡出、無水無泡、LensFactor)、`MorphRainRendererTests` 加 water 3 fill smoke。test csproj 連結 `WaterField`(純) + `WaterRenderer`。build 0 warning、測試全綠。
+
+#### 修訂（依實機回饋）
+1. **滿水後整個特效淡出**：新增 `FadeOutSeconds`（主UI，預設 0.5）。`EffectAlpha(te,full,fade)`＝滿水前/當下＝1、滿後 `fade` 秒內 1→0、之後 0；renderer 收尾把整張往 `aboveSrc`（原樣）blend → 折射＋泡泡一起消失。engine 在 `fill<=0 || alpha<=0` 時直接 clone（純原片）。morph 不淡出（`effectAlpha` 預設 1）。
+2. **泡泡不再被水面硬切**：改「永不抵達水面、接近時淡出」——每顆算 `distToSurface`，在抵達前一個 band 內 `surfaceFade` 1→0（`distToSurface<=r` 即為 0），故畫到時早已淡掉、不會出現被水平線切掉的半圓。renderer 的 lens 也依泡泡可見度 blend 回 pass1（淡的泡泡不會還在全力扭曲）。
+3. **泡泡更像潛水吐氣**：升速大幅放慢（`riseSpeed≈0.12·(0.55+0.9·depth)` canvas/sec）、**左右漂動**加大（兩條慢正弦）、**水壓膨脹**（接近水面半徑×(1+0.45·rise)）。
+4. **泡泡數自動**：移除使用者設定，`AutoBubbleCount(w,h)=clamp(w·h/16000, 4, 20)`（不多、悠閒）。主UI dialog 的「泡泡數」改成「淡出（秒）」；morph 水組移除泡泡數欄。`WaterDialog_BubbleCount` resx 鍵留著未用（無害）。

--- a/docs/CreativeFeatureIdeas.md
+++ b/docs/CreativeFeatureIdeas.md
@@ -24,6 +24,7 @@
 - ✅ **通用尺寸開關（保持原始尺寸 / 不縮到 766px）** — 水波紋/風/流沙底層 math 本就尺寸無關，加 per-dialog 勾選框把它們當通用 GIF 特效用（非 Steam 前置）；大檔先估記憶體、超門檻跳警告可取消。拉霸/格網維持 766-only（語意是 5 槽位）。
 - ✅ **下雨疊層特效（Rain Overlay）**（已實機測試 OK）— 在 GIF 上疊一層半透明雨絲（overlay 合成，非位移）：雨量、風強度、風向、開始秒數、長度、雨停 fade-out + 淡出秒數；比照 wind 的 play-along / frozen-then-play 與時間窗。雨絲用種子化 hash + 畫布 wrap、DDA 畫線 alpha-blend 寫進 RGBA buffer（沿 repo 不用 Drawables 慣例）。
 - ✅ **疊圖轉換 A→B（Morph Transition）**（已實機測試 OK；5 風格）— 兩 clip 全新時間模型（先播 A → A 在窗內轉成 B、A 結束全透明消失 → 播 B 剩餘；總長 = PreRoll + Bdur）。同一 dialog 切換 5 風格：**雨滴暈染**（種子化雨滴 soft-disc coverage cross-dissolve、GlobalFloor 保證收尾全 B）、**翻轉拼圖**（近正方格、種子錯開逐格 squash 翻面、方向隨機/固定）、**聚光燈 Spotlight**（圓形探照撞球式反彈、只照處顯 B、末段擴大填滿）、**拼圖 Jigsaw**（區塊種子順序逐塊拼上顯 B、邊界線可指定色/透明、拼完淡出）、**疊磚 Brick**（B 的木板由遠端一片片自由落體掉下、撞底阻尼彈跳後疊好；高度/g/重量/硬度塑形彈跳，4 方向）。math 抽純函式單測（`RaindropRevealField`/`TileFlipGeometry`/`SpotlightField`/`JigsawGeometry`/`BrickField`/`MorphTimeline`）。
+- ✅ **灌滿水 + 水中氣泡（Water Fill）** — 水由四方向之一逐漸灌滿；水面下＝折射扭曲＋透過上升氣泡（透鏡）看到的影像、水面上不變、水面波浪搖動；氣泡分 ≥3 遠近層、升到水面移出。**主UI 特效**（單一 GIF：水面下＝同片折射）＋**疊圖轉換風格**（第 6 種：水面下＝GIF B、水面上＝GIF A）共用 `WaterField`(純)/`WaterRenderer`(Magick，above/below 參數化)。
 - ✅ **SIMD 評估（延後）** — 維持 `Parallel.For`；熱點（bilinear 取樣、raindrop cross-dissolve）與動手條件（`AllowUnsafeBlocks` + `System.Numerics.Vector`/`Intrinsics`、先 benchmark）記於 dev log。
 
 ---

--- a/src/Core/GifProcessor.Morph.cs
+++ b/src/Core/GifProcessor.Morph.cs
@@ -190,6 +190,9 @@ namespace GifProcessorApp
             BrickParams brick = settings.Style == MorphStyle.Brick
                 ? settings.ToBrickParams()
                 : default;
+            WaterParams water = settings.Style == MorphStyle.WaterFill
+                ? settings.ToWaterParams()
+                : default;
 
             var result = new MagickImageCollection();
             int built = 0;
@@ -231,6 +234,10 @@ namespace GifProcessorApp
                         break;
                     case MorphStyle.Brick:
                         frame = BrickRenderer.RenderFrame(aSrc[idxA], bFit[idxB], t, brick);
+                        break;
+                    case MorphStyle.WaterFill:
+                        // Fill rises over the morph window (t); te (elapsed seconds) animates the bubbles.
+                        frame = WaterRenderer.RenderFrame(aSrc[idxA], bFit[idxB], t, (double)k / fps, water);
                         break;
                     default:
                         frame = RaindropRevealRenderer.RenderFrame(aSrc[idxA], bFit[idxB], t, drops, settings.SoftEdge);

--- a/src/Core/GifProcessor.Water.cs
+++ b/src/Core/GifProcessor.Water.cs
@@ -1,0 +1,234 @@
+using ImageMagick;
+using SteamGifCropper;
+using SteamGifCropper.Properties;
+using System;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+
+namespace GifProcessorApp
+{
+    public static partial class GifProcessor
+    {
+        #region Water Fill (灌水 + 氣泡) Methods
+
+        // Fill an image / GIF with rising water (refraction shimmer + lensing bubbles below the wavy
+        // surface, nothing above it). Output is a single full-width 766px GIF (no auto-split), chainable.
+        public static async Task WaterStaticImage(GifToolMainForm mainForm)
+        {
+            using var dialog = new WaterDialog(false);
+            if (dialog.ShowDialog(mainForm) != DialogResult.OK)
+            {
+                return;
+            }
+            await RunWater(mainForm, dialog.BuildSettings(false));
+        }
+
+        public static async Task WaterGif(GifToolMainForm mainForm)
+        {
+            using var dialog = new WaterDialog(true);
+            if (dialog.ShowDialog(mainForm) != DialogResult.OK)
+            {
+                return;
+            }
+            await RunWater(mainForm, dialog.BuildSettings(true));
+        }
+
+        private static async Task RunWater(GifToolMainForm mainForm, WaterSettings settings)
+        {
+            mainForm.Enabled = false;
+            SetProgressRange(mainForm, 0, 100);
+            SetProgressBar(mainForm.pBarTaskStatus, 0, 100);
+            SetProgressVisible(mainForm, true);
+
+            bool canceled = false;
+            try
+            {
+                await Task.Run(() =>
+                {
+                    SetStatusText(mainForm, SteamGifCropper.Properties.Resources.Status_WaterBuilding);
+                    using var source = new MagickImageCollection(settings.InputFilePath);
+                    source.Coalesce();
+
+                    uint width = source[0].Width;
+                    if (!settings.KeepOriginalSize && !IsValidCanvasWidth(width))
+                    {
+                        foreach (var frame in source)
+                        {
+                            frame.ResetPage();
+                            frame.Resize(SupportedWidth1, 0);
+                        }
+                        width = source[0].Width;
+                    }
+
+                    int outFrames = (settings.IsGif && settings.PlayGifDuringWater)
+                        ? source.Count
+                        : (int)Math.Round(Math.Max(0.1, settings.DurationSeconds) * Math.Max(1, settings.Fps)) + (settings.IsGif ? source.Count : 0);
+                    if (!ConfirmLargeCanvas(mainForm, Math.Max(source.Count, outFrames), width, source[0].Height))
+                    {
+                        canceled = true;
+                        return;
+                    }
+
+                    using var animation = BuildWaterAnimation(mainForm, source, settings);
+                    SetStatusText(mainForm, SteamGifCropper.Properties.Resources.Status_Saving);
+                    animation.Optimize();
+                    animation.Write(settings.OutputFilePath);
+                });
+
+                if (!canceled)
+                {
+                    SetProgressBar(mainForm.pBarTaskStatus, 100, 100);
+                    SetStatusText(mainForm, SteamGifCropper.Properties.Resources.Status_Done);
+                    WindowsThemeManager.ShowThemeAwareMessageBox(mainForm,
+                        SteamGifCropper.Properties.Resources.Message_ProcessingComplete,
+                        SteamGifCropper.Properties.Resources.Title_Success,
+                        MessageBoxButtons.OK, MessageBoxIcon.Information);
+                }
+            }
+            catch (Exception ex)
+            {
+                SetStatusText(mainForm, SteamGifCropper.Properties.Resources.Status_Error);
+                WindowsThemeManager.ShowThemeAwareMessageBox(mainForm,
+                    string.Format(SteamGifCropper.Properties.Resources.Error_Occurred, ex.Message),
+                    SteamGifCropper.Properties.Resources.Title_Error,
+                    MessageBoxButtons.OK, MessageBoxIcon.Error);
+            }
+            finally
+            {
+                mainForm.Enabled = true;
+                SetProgressBar(mainForm.pBarTaskStatus, 0, 100);
+                SetStatusText(mainForm, SteamGifCropper.Properties.Resources.Status_Idle);
+            }
+        }
+
+        private static MagickImageCollection BuildWaterAnimation(GifToolMainForm mainForm,
+            MagickImageCollection source, WaterSettings settings)
+        {
+            int srcTicks = (int)source[0].AnimationTicksPerSecond;
+            if (srcTicks <= 0) srcTicks = 100;
+            WaterParams water = settings.ToParams();
+
+            if (settings.IsGif && settings.PlayGifDuringWater)
+            {
+                return BuildWaterPlayAlong(mainForm, source, settings, water, srcTicks);
+            }
+            return BuildWaterFrozenThenPlay(mainForm, source, settings, water, srcTicks);
+        }
+
+        // Output length == source GIF length, native timing. Water fills over the live frames between
+        // StartSeconds and FullSeconds; before the start the frame passes through unchanged; once full it
+        // stays full so the rest of the GIF plays fully submerged (the no-truncate invariant: the whole
+        // clip still plays).
+        private static MagickImageCollection BuildWaterPlayAlong(GifToolMainForm mainForm,
+            MagickImageCollection source, WaterSettings settings, WaterParams water, int srcTicks)
+        {
+            int n = source.Count;
+            double[] startSec = new double[n];
+            double acc = 0.0;
+            for (int i = 0; i < n; i++)
+            {
+                startSec[i] = acc;
+                acc += (double)source[i].AnimationDelay / srcTicks;
+            }
+
+            var result = new MagickImageCollection();
+            int built = 0;
+            for (int i = 0; i < n; i++)
+            {
+                double te = startSec[i];
+                double fill = WaterField.FillFrac(te, settings.StartSeconds, settings.FullSeconds);
+                double alpha = WaterField.EffectAlpha(te, settings.FullSeconds, settings.FadeOutSeconds);
+                MagickImage frame;
+                if (fill > 0.0 && alpha > 0.0)
+                {
+                    frame = WaterRenderer.RenderFrame(source[i], source[i], fill, te, water, alpha);
+                }
+                else
+                {
+                    frame = (MagickImage)source[i].Clone();
+                }
+                frame.ResetPage();
+                frame.AnimationDelay = source[i].AnimationDelay;
+                frame.AnimationTicksPerSecond = srcTicks;
+                frame.GifDisposeMethod = GifDisposeMethod.Background;
+                result.Add(frame);
+
+                if (++built % 5 == 0 || built == n)
+                {
+                    SetProgressBar(mainForm.pBarTaskStatus, built * 100 / n, 100);
+                    SetStatusText(mainForm, SteamGifCropper.Properties.Resources.Status_WaterBuilding);
+                }
+            }
+            return result;
+        }
+
+        // Water fills over a frozen frame 0 for `Duration` seconds at the chosen FPS, then (GIF) the full
+        // source GIF plays fully submerged; a static image is just the fill animation.
+        private static MagickImageCollection BuildWaterFrozenThenPlay(GifToolMainForm mainForm,
+            MagickImageCollection source, WaterSettings settings, WaterParams water, int srcTicks)
+        {
+            int fps = Math.Max(1, settings.Fps);
+            int delay = Math.Max(1, (int)Math.Round(100.0 / fps));
+            double duration = settings.DurationSeconds;
+            if (duration < 0.1) duration = 0.1;
+            int fillFrames = Math.Max(1, (int)Math.Round(duration * fps));
+            int playFrames = settings.IsGif ? source.Count : 0;
+            int totalFrames = fillFrames + playFrames;
+
+            var result = new MagickImageCollection();
+            int built = 0;
+
+            // Phase 1: water rises over the frozen first frame, then fades out.
+            for (int f = 0; f < fillFrames; f++)
+            {
+                double te = (double)f / fps;
+                double fill = WaterField.FillFrac(te, settings.StartSeconds, settings.FullSeconds);
+                double alpha = WaterField.EffectAlpha(te, settings.FullSeconds, settings.FadeOutSeconds);
+                MagickImage frame = (fill > 0.0 && alpha > 0.0)
+                    ? WaterRenderer.RenderFrame(source[0], source[0], fill, te, water, alpha)
+                    : (MagickImage)source[0].Clone();
+                frame.ResetPage();
+                frame.AnimationDelay = (uint)delay;
+                frame.AnimationTicksPerSecond = 100;
+                frame.GifDisposeMethod = GifDisposeMethod.Background;
+                result.Add(frame);
+
+                if (++built % 5 == 0 || built == totalFrames)
+                {
+                    SetProgressBar(mainForm.pBarTaskStatus, built * 100 / totalFrames, 100);
+                    SetStatusText(mainForm, SteamGifCropper.Properties.Resources.Status_WaterBuilding);
+                }
+            }
+
+            // Phase 2 (GIF only): play the full source GIF. While the water is still up it is submerged;
+            // once it has faded out (alpha == 0) the frames play plain.
+            if (settings.IsGif)
+            {
+                double te = duration;
+                for (int i = 0; i < source.Count; i++)
+                {
+                    double alpha = WaterField.EffectAlpha(te, settings.FullSeconds, settings.FadeOutSeconds);
+                    MagickImage play = alpha > 0.0
+                        ? WaterRenderer.RenderFrame(source[i], source[i], 1.0, te, water, alpha)
+                        : (MagickImage)source[i].Clone();
+                    play.ResetPage();
+                    play.AnimationDelay = source[i].AnimationDelay;
+                    play.AnimationTicksPerSecond = srcTicks;
+                    play.GifDisposeMethod = GifDisposeMethod.Background;
+                    result.Add(play);
+                    te += (double)source[i].AnimationDelay / srcTicks;
+
+                    if (++built % 5 == 0 || built == totalFrames)
+                    {
+                        SetProgressBar(mainForm.pBarTaskStatus, built * 100 / totalFrames, 100);
+                        SetStatusText(mainForm, SteamGifCropper.Properties.Resources.Status_WaterBuilding);
+                    }
+                }
+            }
+
+            return result;
+        }
+
+        #endregion
+    }
+}

--- a/src/Core/MorphSettings.cs
+++ b/src/Core/MorphSettings.cs
@@ -10,6 +10,7 @@ namespace GifProcessorApp
         Spotlight = 2,      // a bouncing searchlight reveals B, then expands to fill the frame
         Jigsaw = 3,         // puzzle pieces fill in A->B one by one, with fading boundary lines
         Brick = 4,          // planks of B drop in and stack over A with an impact bounce
+        WaterFill = 5,      // water rises over A; below the surface (refracted, with bubbles) shows B
     }
 
     // Tile-flip squash axis / sense. Up/Down squash vertically, Left/Right horizontally; Random picks a
@@ -95,6 +96,27 @@ namespace GifProcessorApp
                 Gravity = BrickGravity,
                 Weight = BrickWeight,
                 Hardness = BrickHardness / 100.0,
+            };
+        }
+
+        // Water-fill style (the fill rises over the morph window; below the surface shows B refracted with
+        // rising bubbles, above shows A).
+        public WaterDirection WaterDirection { get; set; } = WaterDirection.Up;
+        public double WaterRefraction { get; set; } = 4.0;
+        public double WaterWobble { get; set; } = 6.0;
+        public double WaterBubbleSize { get; set; } = 12.0;
+        public int WaterLayers { get; set; } = 3;
+
+        public WaterParams ToWaterParams()
+        {
+            return new WaterParams
+            {
+                Direction = WaterDirection,
+                RefractionStrength = WaterRefraction,
+                SurfaceWobble = WaterWobble,
+                BubbleSize = WaterBubbleSize,
+                Layers = Math.Max(1, WaterLayers),
+                Seed = Seed,
             };
         }
     }

--- a/src/Core/WaterField.cs
+++ b/src/Core/WaterField.cs
@@ -1,0 +1,196 @@
+using System;
+
+namespace GifProcessorApp
+{
+    // Which way the water fills. Up = rises from the bottom (the normal case); the same algorithm runs in
+    // all four directions. Enum order matches the dialog's direction dropdown index.
+    public enum WaterDirection
+    {
+        Up = 0,    // fills from the bottom, surface rises
+        Down = 1,  // fills from the top
+        Left = 2,  // fills from the left
+        Right = 3, // fills from the right
+    }
+
+    // Resolved per-canvas water parameters (WaterSettings.ToParams builds this).
+    public struct WaterParams
+    {
+        public WaterDirection Direction;
+        public double RefractionStrength; // px: underwater shimmer (light distortion) amplitude
+        public double SurfaceWobble;      // px: surface wave amplitude
+        public double BubbleSize;         // px: base bubble radius (count is auto from the canvas area)
+        public int Layers;                // depth layers (>= 3): far = small/slow/faint, near = big/strong
+        public int Seed;
+    }
+
+    // One bubble for a single frame (already known to be underwater).
+    public struct WaterBubble
+    {
+        public double X, Y;   // centre (px)
+        public double R;      // radius (px)
+        public double Opacity;// 0..1 rim/fill opacity
+        public double Lens;   // 0..1 lens (magnification) strength
+    }
+
+    // Pure, dependency-free math for the "fill with water + rising bubbles" effect (linked into the test
+    // project; WaterRenderer does the Magick sampling). Water fills from a chosen direction between a start
+    // and a full time; below the wavy, wobbling surface the source is refracted (a gentle shimmer) and seen
+    // through rising bubbles that act as little lenses; above the surface nothing changes. Bubbles span
+    // >= 3 depth layers (auto near/far) and exit when they reach the surface.
+    public static class WaterField
+    {
+        // Fill fraction 0..1 at effect-elapsed time te, ramping from 0 at startSec to 1 at fullSec and
+        // staying full afterwards.
+        public static double FillFrac(double te, double startSec, double fullSec)
+        {
+            if (te <= startSec) return 0.0;
+            if (fullSec <= startSec) return 1.0;
+            double f = (te - startSec) / (fullSec - startSec);
+            return f < 0.0 ? 0.0 : f > 1.0 ? 1.0 : f;
+        }
+
+        // Overall effect opacity at elapsed time te: 1 while filling and full, then fading 1 -> 0 over
+        // fadeSeconds once the tank is full, so the whole water effect (refraction + bubbles) disappears
+        // and the source returns to normal. fadeSeconds <= 0 keeps the water to the end (no fade).
+        public static double EffectAlpha(double te, double fullSec, double fadeSeconds)
+        {
+            if (fadeSeconds <= 0.0) return 1.0;
+            if (te <= fullSec) return 1.0;
+            double a = 1.0 - (te - fullSec) / fadeSeconds;
+            return a < 0.0 ? 0.0 : a > 1.0 ? 1.0 : a;
+        }
+
+        // Auto bubble count from the canvas area — modest, so the bubbles drift up leisurely rather than
+        // swarm (the user doesn't set the count).
+        public static int AutoBubbleCount(int w, int h)
+        {
+            int c = (int)Math.Round((double)Math.Max(1, w) * Math.Max(1, h) / 16000.0);
+            if (c < 4) c = 4;
+            if (c > 20) c = 20;
+            return c;
+        }
+
+        public static bool Vertical(WaterDirection d) => d == WaterDirection.Up || d == WaterDirection.Down;
+
+        // The surface coordinate along the fill axis at perpendicular position `perp` and time te. A wavy,
+        // wobbling line; the wave fades out as the tank empties/fills so it is flat at the extremes.
+        public static double Surface(double perp, double te, double fillFrac, int axisLen, int perpLen, WaterParams p)
+        {
+            // Down/Left fill from the low end (surface = fill); Up/Right fill from the high end (surface = 1-fill).
+            bool fromLow = p.Direction == WaterDirection.Down || p.Direction == WaterDirection.Left;
+            double baseS = fromLow ? axisLen * fillFrac : axisLen * (1.0 - fillFrac);
+            double pl = Math.Max(1.0, perpLen);
+            double fade = 4.0 * fillFrac * (1.0 - fillFrac); // 0 at empty/full, 1 at half
+            double wave = p.SurfaceWobble * fade * Math.Sin(2.0 * Math.PI * perp / (pl / 1.5) + te * 3.0);
+            return baseS + wave;
+        }
+
+        // Whether pixel (x,y) is below the water surface (i.e. submerged).
+        public static bool IsUnderwater(int x, int y, double te, double fillFrac, int w, int h, WaterParams p)
+        {
+            if (fillFrac <= 0.0) return false;
+            bool vertical = Vertical(p.Direction);
+            int axisLen = vertical ? h : w;
+            int perpLen = vertical ? w : h;
+            double perp = vertical ? x : y;
+            double axisPos = vertical ? y : x;
+            double s = Surface(perp, te, fillFrac, axisLen, perpLen, p);
+            switch (p.Direction)
+            {
+                case WaterDirection.Up: return axisPos > s;     // water at the bottom
+                case WaterDirection.Down: return axisPos < s;   // water at the top
+                case WaterDirection.Left: return axisPos < s;   // water at the left
+                default: return axisPos > s;                    // Right: water at the right
+            }
+        }
+
+        // Underwater refraction shimmer (light distortion): a gentle time-varying sinusoidal displacement.
+        public static (double Dx, double Dy) Shimmer(double x, double y, double te, WaterParams p)
+        {
+            double a = p.RefractionStrength;
+            double dx = a * Math.Sin(0.05 * y + te * 2.0) * 0.8 + a * 0.3 * Math.Sin(0.09 * x - te * 1.3);
+            double dy = a * 0.4 * Math.Sin(0.06 * x + te * 1.7);
+            return (dx, dy);
+        }
+
+        // Lens sampling scale at distance `dist` from a bubble centre of radius r: < 1 inside (magnifies),
+        // ramping back to 1 at the rim. Pixels outside (dist > r) are unaffected (returns 1).
+        public static double LensFactor(double dist, double r, double strength)
+        {
+            if (r <= 1e-6 || dist >= r) return 1.0;
+            double t = dist / r;              // 0 centre .. 1 rim
+            double mag = 1.0 - strength * (1.0 - t * t); // strongest magnification at the centre
+            if (mag < 0.2) mag = 0.2;
+            return mag;
+        }
+
+        // The bubbles visible at time te. Each belongs to a depth layer (auto near/far: far = small/faint/
+        // weak lens). Bubbles drift toward the surface slowly with a left-right sway, swell a little as the
+        // pressure drops near the surface, and fade out over a band before the waterline (so they never get
+        // hard-clipped at the surface) — like a diver's exhaled bubbles drifting up and dissolving.
+        public static WaterBubble[] Bubbles(double te, double fillFrac, int w, int h, WaterParams p)
+        {
+            if (fillFrac <= 0.0) return Array.Empty<WaterBubble>();
+            int count = AutoBubbleCount(w, h);
+
+            bool vertical = Vertical(p.Direction);
+            bool fromLow = p.Direction == WaterDirection.Down || p.Direction == WaterDirection.Left;
+            int axisLen = vertical ? h : w;
+            int perpLen = vertical ? w : h;
+            int layers = p.Layers < 1 ? 1 : p.Layers;
+
+            var list = new System.Collections.Generic.List<WaterBubble>(count);
+            for (int i = 0; i < count; i++)
+            {
+                int layer = i % layers;
+                double depth = layers > 1 ? (double)layer / (layers - 1) : 1.0; // 0 far .. 1 near
+                double baseR = p.BubbleSize * (0.4 + 0.9 * depth) * (0.7 + 0.6 * RainField.Hash01(i, 41, p.Seed));
+                double riseSpeed = 0.12 * (0.55 + 0.9 * depth); // canvas fractions / sec (slow, leisurely)
+                double opacity = 0.25 + 0.45 * depth;
+                double lens = 0.2 + 0.6 * depth;
+                double lane = RainField.Hash01(i, 42, p.Seed);
+                double phase = RainField.Hash01(i, 43, p.Seed);
+
+                double travel = phase + te * riseSpeed;
+                double frac = travel - Math.Floor(travel); // 0..1 along the rise toward the surface
+
+                double axisPos;
+                switch (p.Direction)
+                {
+                    case WaterDirection.Up: axisPos = axisLen * (1.0 - frac); break;
+                    case WaterDirection.Down: axisPos = axisLen * frac; break;
+                    case WaterDirection.Left: axisPos = axisLen * frac; break;
+                    default: axisPos = axisLen * (1.0 - frac); break; // Right
+                }
+
+                // Left-right drift: two slow sines for an organic, pressure-driven wobble.
+                double swayAmp = perpLen * 0.05 * (0.5 + 0.8 * RainField.Hash01(i, 44, p.Seed));
+                double ph2 = RainField.Hash01(i, 45, p.Seed) * 6.2831853;
+                double sway = swayAmp * (0.7 * Math.Sin(te * 1.1 + ph2) + 0.3 * Math.Sin(te * 0.43 + i));
+                double perpPos = lane * perpLen + sway;
+
+                // How far below the surface the bubble centre is (along the fill axis).
+                double surf = Surface(perpPos, te, fillFrac, axisLen, perpLen, p);
+                double distToSurface = fromLow ? (surf - axisPos) : (axisPos - surf);
+                if (distToSurface <= 0.0) continue;
+
+                // Water pressure: swell a little as it nears the surface.
+                double rise = 1.0 - Math.Min(1.0, distToSurface / axisLen);
+                double r = baseR * (1.0 + 0.45 * rise);
+
+                // Fade out over a band before the surface so it is gone before it would be clipped.
+                double fadeBand = Math.Max(r * 2.0, axisLen * 0.14);
+                double surfaceFade = (distToSurface - r) / fadeBand;
+                if (surfaceFade <= 0.0) continue;
+                if (surfaceFade > 1.0) surfaceFade = 1.0;
+                double op = opacity * surfaceFade;
+                if (op <= 0.01) continue;
+
+                double bx = vertical ? perpPos : axisPos;
+                double by = vertical ? axisPos : perpPos;
+                list.Add(new WaterBubble { X = bx, Y = by, R = Math.Max(1.0, r), Opacity = op, Lens = lens });
+            }
+            return list.ToArray();
+        }
+    }
+}

--- a/src/Core/WaterRenderer.cs
+++ b/src/Core/WaterRenderer.cs
@@ -1,0 +1,188 @@
+using System;
+using System.Threading.Tasks;
+using ImageMagick;
+
+namespace GifProcessorApp
+{
+    // Renders one "water fill + bubbles" frame onto a raw RGBA byte[] (Q8). Above the wavy surface the
+    // output is `aboveSrc` unchanged; below it the output is `belowSrc` refracted by a gentle shimmer and,
+    // where bubbles sit, magnified through them with a bright rim + highlight. The water level / surface /
+    // bubble schedule come from the pure WaterField. The above/below sources are separate so the same
+    // renderer serves both the single-GIF effect (above == below == the frame) and the A->B morph
+    // (above == A, below == B).
+    public static class WaterRenderer
+    {
+        // effectAlpha (0..1) fades the whole water effect toward the plain `aboveSrc` (1 = full water,
+        // 0 = no effect) — used by the main-UI fade-out after the tank is full. The morph passes 1.
+        public static MagickImage RenderFrame(IMagickImage<byte> aboveSrc, IMagickImage<byte> belowSrc,
+            double fillFrac, double te, WaterParams p, double effectAlpha = 1.0)
+        {
+            uint w = aboveSrc.Width;
+            uint h = aboveSrc.Height;
+            int iw = (int)w;
+            int ih = (int)h;
+
+            byte[] above, below;
+            using (var sp = aboveSrc.GetPixels()) above = sp.ToByteArray("RGBA")!;
+            using (var sp = belowSrc.GetPixels()) below = sp.ToByteArray("RGBA")!;
+            byte[] dst = new byte[above.Length];
+
+            bool hasWater = fillFrac > 0.0 && effectAlpha > 0.0;
+
+            // Pass 1: above the surface = aboveSrc as-is; below = belowSrc with the refraction shimmer.
+            Parallel.For(0, ih, y =>
+            {
+                int rowBase = y * iw * 4;
+                for (int x = 0; x < iw; x++)
+                {
+                    int idx = rowBase + x * 4;
+                    if (hasWater && WaterField.IsUnderwater(x, y, te, fillFrac, iw, ih, p))
+                    {
+                        var (dx, dy) = WaterField.Shimmer(x, y, te, p);
+                        SampleBilinearRgba(below, iw, ih, x + dx, y + dy, dst, idx);
+                    }
+                    else
+                    {
+                        dst[idx] = above[idx];
+                        dst[idx + 1] = above[idx + 1];
+                        dst[idx + 2] = above[idx + 2];
+                        dst[idx + 3] = above[idx + 3];
+                    }
+                }
+            });
+
+            // Pass 2: bubbles (sequential; far/small first so near/big draw on top).
+            if (hasWater)
+            {
+                WaterBubble[] bubbles = WaterField.Bubbles(te, fillFrac, iw, ih, p);
+                Array.Sort(bubbles, (a, b) => a.R.CompareTo(b.R));
+                foreach (var b in bubbles)
+                {
+                    DrawBubble(dst, below, iw, ih, te, fillFrac, p, b);
+                }
+            }
+
+            // Fade-out: blend the whole water result toward the plain (above) source.
+            if (effectAlpha < 1.0)
+            {
+                double alpha = effectAlpha < 0.0 ? 0.0 : effectAlpha;
+                double inv = 1.0 - alpha;
+                Parallel.For(0, ih, y =>
+                {
+                    int rowBase = y * iw * 4;
+                    for (int x = 0; x < iw; x++)
+                    {
+                        int idx = rowBase + x * 4;
+                        for (int c = 0; c < 4; c++)
+                            dst[idx + c] = (byte)(above[idx + c] * inv + dst[idx + c] * alpha + 0.5);
+                    }
+                });
+            }
+
+            var settings = new PixelReadSettings(w, h, StorageType.Char, "RGBA");
+            var outImg = new MagickImage();
+            outImg.ReadPixels(dst, settings);
+            outImg.ResetPage();
+            return outImg;
+        }
+
+        private static void DrawBubble(byte[] dst, byte[] below, int w, int h, double te,
+            double fillFrac, WaterParams p, WaterBubble b)
+        {
+            int x0 = Math.Max(0, (int)Math.Floor(b.X - b.R - 1));
+            int x1 = Math.Min(w - 1, (int)Math.Ceiling(b.X + b.R + 1));
+            int y0 = Math.Max(0, (int)Math.Floor(b.Y - b.R - 1));
+            int y1 = Math.Min(h - 1, (int)Math.Ceiling(b.Y + b.R + 1));
+            double hx = b.X - 0.32 * b.R, hy = b.Y - 0.32 * b.R; // specular highlight centre
+            double bubbleAlpha = Math.Min(1.0, b.Opacity * 1.8);  // overall visibility (fades near the surface)
+            double binv = 1.0 - bubbleAlpha;
+            byte[] tmp = new byte[4];
+
+            for (int py = y0; py <= y1; py++)
+            {
+                for (int px = x0; px <= x1; px++)
+                {
+                    double ddx = px - b.X, ddy = py - b.Y;
+                    double dist = Math.Sqrt(ddx * ddx + ddy * ddy);
+                    if (dist > b.R) continue;
+                    if (!WaterField.IsUnderwater(px, py, te, fillFrac, w, h, p)) continue;
+
+                    int idx = (py * w + px) * 4;
+
+                    // Lens: sample the underwater source magnified toward the bubble centre (+ shimmer),
+                    // blended toward the existing underwater pixel by the bubble's visibility so a fading
+                    // bubble dissolves rather than distorting at full strength.
+                    double m = WaterField.LensFactor(dist, b.R, b.Lens);
+                    double sx = b.X + ddx * m;
+                    double sy = b.Y + ddy * m;
+                    var (shx, shy) = WaterField.Shimmer(sx, sy, te, p);
+                    SampleBilinearRgba(below, w, h, sx + shx, sy + shy, tmp, 0);
+                    dst[idx] = (byte)(dst[idx] * binv + tmp[0] * bubbleAlpha + 0.5);
+                    dst[idx + 1] = (byte)(dst[idx + 1] * binv + tmp[1] * bubbleAlpha + 0.5);
+                    dst[idx + 2] = (byte)(dst[idx + 2] * binv + tmp[2] * bubbleAlpha + 0.5);
+                    dst[idx + 3] = (byte)(dst[idx + 3] * binv + tmp[3] * bubbleAlpha + 0.5);
+
+                    // Bright rim near the edge.
+                    double rim = dist / b.R;
+                    if (rim > 0.82)
+                    {
+                        double k = (rim - 0.82) / 0.18 * b.Opacity;
+                        BlendWhite(dst, idx, k);
+                    }
+
+                    // Specular highlight spot.
+                    double hdx = px - hx, hdy = py - hy;
+                    double hd = Math.Sqrt(hdx * hdx + hdy * hdy);
+                    if (hd < b.R * 0.22)
+                    {
+                        double k = (1.0 - hd / (b.R * 0.22)) * 0.6 * b.Opacity;
+                        BlendWhite(dst, idx, k);
+                    }
+                }
+            }
+        }
+
+        private static void BlendWhite(byte[] buf, int idx, double a)
+        {
+            if (a <= 0.0) return;
+            if (a > 1.0) a = 1.0;
+            double inv = 1.0 - a;
+            buf[idx] = (byte)(buf[idx] * inv + 255 * a + 0.5);
+            buf[idx + 1] = (byte)(buf[idx + 1] * inv + 255 * a + 0.5);
+            buf[idx + 2] = (byte)(buf[idx + 2] * inv + 255 * a + 0.5);
+            int na = (int)(buf[idx + 3] + a * 255.0 + 0.5);
+            buf[idx + 3] = na > 255 ? (byte)255 : (byte)na;
+        }
+
+        // Bilinear RGBA sample, edge-clamped (copied from the ripple/wind resamplers).
+        private static void SampleBilinearRgba(byte[] src, int w, int h, double sx, double sy, byte[] dst, int di)
+        {
+            if (sx < 0.0) sx = 0.0; else if (sx > w - 1) sx = w - 1;
+            if (sy < 0.0) sy = 0.0; else if (sy > h - 1) sy = h - 1;
+
+            int x0 = (int)Math.Floor(sx);
+            int y0 = (int)Math.Floor(sy);
+            int x1 = x0 + 1; if (x1 > w - 1) x1 = w - 1;
+            int y1 = y0 + 1; if (y1 > h - 1) y1 = h - 1;
+
+            double fx = sx - x0;
+            double fy = sy - y0;
+            double w00 = (1.0 - fx) * (1.0 - fy);
+            double w10 = fx * (1.0 - fy);
+            double w01 = (1.0 - fx) * fy;
+            double w11 = fx * fy;
+
+            int i00 = (y0 * w + x0) * 4;
+            int i10 = (y0 * w + x1) * 4;
+            int i01 = (y1 * w + x0) * 4;
+            int i11 = (y1 * w + x1) * 4;
+
+            for (int c = 0; c < 4; c++)
+            {
+                double v = src[i00 + c] * w00 + src[i10 + c] * w10 + src[i01 + c] * w01 + src[i11 + c] * w11;
+                int iv = (int)(v + 0.5);
+                dst[di + c] = iv < 0 ? (byte)0 : iv > 255 ? (byte)255 : (byte)iv;
+            }
+        }
+    }
+}

--- a/src/Core/WaterSettings.cs
+++ b/src/Core/WaterSettings.cs
@@ -1,0 +1,45 @@
+using System;
+
+namespace GifProcessorApp
+{
+    // Parameters captured from WaterDialog and consumed by the GifProcessor water engine. The canvas fills
+    // with water from a chosen direction between StartSeconds and FullSeconds; below the wavy surface the
+    // image is refracted and seen through rising, lensing bubbles, above it nothing changes. Output is a
+    // single full-width 766px GIF (no auto-split), chainable. BuildSettings() does the control->settings map.
+    public class WaterSettings
+    {
+        public string InputFilePath { get; set; }
+        public string OutputFilePath { get; set; }
+        public bool IsGif { get; set; }
+
+        // Scene
+        public int Fps { get; set; } = 20;
+        public double DurationSeconds { get; set; } = 6.0;    // frozen / static mode length
+        public bool PlayGifDuringWater { get; set; } = true;  // GIF: fill over live frames vs frozen frame 0
+        public bool KeepOriginalSize { get; set; } = false;
+
+        // Water
+        public WaterDirection Direction { get; set; } = WaterDirection.Up;
+        public double StartSeconds { get; set; } = 0.5;        // when the water starts rising
+        public double FullSeconds { get; set; } = 4.0;         // when the water reaches the full level
+        public double FadeOutSeconds { get; set; } = 0.5;      // after full, fade the whole effect out (0 = stay)
+        public double RefractionStrength { get; set; } = 4.0;  // px shimmer
+        public double SurfaceWobble { get; set; } = 6.0;       // px surface wave
+        public double BubbleSize { get; set; } = 12.0;         // px base radius (count is auto)
+        public int Layers { get; set; } = 3;                   // depth layers (>= 3)
+        public int Seed { get; set; } = 20240601;
+
+        public WaterParams ToParams()
+        {
+            return new WaterParams
+            {
+                Direction = Direction,
+                RefractionStrength = RefractionStrength,
+                SurfaceWobble = SurfaceWobble,
+                BubbleSize = BubbleSize,
+                Layers = Math.Max(1, Layers),
+                Seed = Seed,
+            };
+        }
+    }
+}

--- a/src/Dialogs/MorphTransitionDialog.cs
+++ b/src/Dialogs/MorphTransitionDialog.cs
@@ -81,11 +81,24 @@ namespace GifProcessorApp
         private Label lblBrickHardness = null!;
         private NumericUpDown numBrickHardness = null!;
 
+        // Water-fill group.
+        private Label lblWaterDir = null!;
+        private ComboBox cmbWaterDir = null!;
+        private Label lblWaterRefraction = null!;
+        private NumericUpDown numWaterRefraction = null!;
+        private Label lblWaterWobble = null!;
+        private NumericUpDown numWaterWobble = null!;
+        private Label lblWaterSize = null!;
+        private NumericUpDown numWaterSize = null!;
+        private Label lblWaterLayers = null!;
+        private NumericUpDown numWaterLayers = null!;
+
         private readonly List<Control> _raindropControls = new List<Control>();
         private readonly List<Control> _tileControls = new List<Control>();
         private readonly List<Control> _spotlightControls = new List<Control>();
         private readonly List<Control> _jigsawControls = new List<Control>();
         private readonly List<Control> _brickControls = new List<Control>();
+        private readonly List<Control> _waterControls = new List<Control>();
 
         private Button btnOK = null!;
         private Button btnCancel = null!;
@@ -135,6 +148,11 @@ namespace GifProcessorApp
                 BrickGravity = (double)numBrickG.Value,
                 BrickWeight = (double)numBrickWeight.Value,
                 BrickHardness = (double)numBrickHardness.Value,
+                WaterDirection = (WaterDirection)cmbWaterDir.SelectedIndex,
+                WaterRefraction = (double)numWaterRefraction.Value,
+                WaterWobble = (double)numWaterWobble.Value,
+                WaterBubbleSize = (double)numWaterSize.Value,
+                WaterLayers = (int)numWaterLayers.Value,
             };
         }
 
@@ -146,6 +164,7 @@ namespace GifProcessorApp
             foreach (var c in _spotlightControls) c.Visible = style == MorphStyle.Spotlight;
             foreach (var c in _jigsawControls) c.Visible = style == MorphStyle.Jigsaw;
             foreach (var c in _brickControls) c.Visible = style == MorphStyle.Brick;
+            foreach (var c in _waterControls) c.Visible = style == MorphStyle.WaterFill;
         }
 
         private void RefreshJigsawColorEnabled()
@@ -194,6 +213,11 @@ namespace GifProcessorApp
             lblBrickG.Text = Resources.MorphDialog_BrickGravity;
             lblBrickWeight.Text = Resources.MorphDialog_BrickWeight;
             lblBrickHardness.Text = Resources.MorphDialog_BrickHardness;
+            lblWaterDir.Text = Resources.WaterDialog_Direction;
+            lblWaterRefraction.Text = Resources.WaterDialog_Refraction;
+            lblWaterWobble.Text = Resources.WaterDialog_Wobble;
+            lblWaterSize.Text = Resources.WaterDialog_BubbleSize;
+            lblWaterLayers.Text = Resources.WaterDialog_Layers;
             btnBrowseA.Text = Resources.Button_Browse;
             btnBrowseB.Text = Resources.Button_Browse;
             btnBrowseOutput.Text = Resources.Button_Browse;
@@ -207,6 +231,7 @@ namespace GifProcessorApp
             cmbStyle.Items.Add(Resources.MorphStyle_Spotlight);
             cmbStyle.Items.Add(Resources.MorphStyle_Jigsaw);
             cmbStyle.Items.Add(Resources.MorphStyle_Brick);
+            cmbStyle.Items.Add(Resources.MorphStyle_Water);
             cmbStyle.SelectedIndex = styleSel;
 
             int dirSel = cmbFlipDir.SelectedIndex < 0 ? 0 : cmbFlipDir.SelectedIndex;
@@ -225,6 +250,14 @@ namespace GifProcessorApp
             cmbBrickDir.Items.Add(Resources.BrickDir_Left);
             cmbBrickDir.Items.Add(Resources.BrickDir_Right);
             cmbBrickDir.SelectedIndex = brickDirSel;
+
+            int waterDirSel = cmbWaterDir.SelectedIndex < 0 ? 0 : cmbWaterDir.SelectedIndex;
+            cmbWaterDir.Items.Clear();
+            cmbWaterDir.Items.Add(Resources.WaterDir_Up);
+            cmbWaterDir.Items.Add(Resources.WaterDir_Down);
+            cmbWaterDir.Items.Add(Resources.WaterDir_Left);
+            cmbWaterDir.Items.Add(Resources.WaterDir_Right);
+            cmbWaterDir.SelectedIndex = waterDirSel;
         }
 
         private void ApplyTheme()
@@ -483,6 +516,18 @@ namespace GifProcessorApp
             lblBrickHardness = new Label { Location = new Point(214, 267), Size = new Size(58, 20), Text = "Hardness" };
             numBrickHardness = MakeNum(276, 265, 56, 0, 0m, 100m, 5m, 50m);
 
+            // --- Water-fill group (same vertical band; fill rises over the morph window) ---
+            lblWaterDir = new Label { Location = new Point(14, 234), Size = new Size(40, 20), Text = "Dir" };
+            cmbWaterDir = new ComboBox { Location = new Point(56, 232), Size = new Size(92, 23), DropDownStyle = ComboBoxStyle.DropDownList };
+            lblWaterRefraction = new Label { Location = new Point(158, 234), Size = new Size(50, 20), Text = "Refract" };
+            numWaterRefraction = MakeNum(210, 232, 56, 1, 0.0m, 30.0m, 0.5m, 4.0m);
+            lblWaterWobble = new Label { Location = new Point(276, 234), Size = new Size(64, 20), Text = "Wobble" };
+            numWaterWobble = MakeNum(342, 232, 56, 1, 0.0m, 40.0m, 0.5m, 6.0m);
+            lblWaterSize = new Label { Location = new Point(14, 267), Size = new Size(72, 20), Text = "Bubble size" };
+            numWaterSize = MakeNum(88, 265, 56, 1, 2.0m, 60.0m, 1.0m, 12.0m);
+            lblWaterLayers = new Label { Location = new Point(154, 267), Size = new Size(46, 20), Text = "Layers" };
+            numWaterLayers = MakeNum(202, 265, 46, 0, 1m, 8m, 1m, 3m);
+
             btnOK = new Button { Location = new Point(363, 312), Size = new Size(75, 25), Text = "OK", UseVisualStyleBackColor = true };
             btnOK.Click += BtnOK_Click;
             btnCancel = new Button { Location = new Point(444, 312), Size = new Size(82, 25), Text = "Cancel", DialogResult = DialogResult.Cancel, UseVisualStyleBackColor = true };
@@ -505,6 +550,11 @@ namespace GifProcessorApp
             {
                 lblBrickPieces, numBrickPieces, lblBrickDir, cmbBrickDir, lblBrickHeight, numBrickHeight,
                 lblBrickG, numBrickG, lblBrickWeight, numBrickWeight, lblBrickHardness, numBrickHardness,
+            });
+            _waterControls.AddRange(new Control[]
+            {
+                lblWaterDir, cmbWaterDir, lblWaterRefraction, numWaterRefraction, lblWaterWobble, numWaterWobble,
+                lblWaterSize, numWaterSize, lblWaterLayers, numWaterLayers,
             });
 
             SuspendLayout();
@@ -531,6 +581,7 @@ namespace GifProcessorApp
             foreach (var c in _spotlightControls) Controls.Add(c);
             foreach (var c in _jigsawControls) Controls.Add(c);
             foreach (var c in _brickControls) Controls.Add(c);
+            foreach (var c in _waterControls) Controls.Add(c);
             Controls.Add(btnOK);
             Controls.Add(btnCancel);
 

--- a/src/Dialogs/WaterDialog.cs
+++ b/src/Dialogs/WaterDialog.cs
@@ -1,0 +1,397 @@
+#nullable enable
+using System;
+using System.Drawing;
+using System.IO;
+using System.Windows.Forms;
+using SteamGifCropper.Properties;
+
+namespace GifProcessorApp
+{
+    // Water-fill (灌水 + 氣泡) parameters dialog. Mirrors the other effect dialogs' inline layout + theme
+    // handling. The canvas fills with water from a chosen direction between start and full seconds; below
+    // the wavy surface the image is refracted and seen through rising bubbles. BuildSettings() does the
+    // control->settings mapping in one place.
+    public class WaterDialog : Form
+    {
+        private readonly bool _isGif;
+
+        private TextBox txtInputPath = null!;
+        private Button btnBrowseInput = null!;
+        private TextBox txtOutputPath = null!;
+        private Button btnBrowseOutput = null!;
+        private Label lblInput = null!;
+        private Label lblOutput = null!;
+
+        private Label lblDirection = null!;
+        private ComboBox cmbDirection = null!;
+        private ComboBox cmbGifPlayMode = null!;
+
+        private Label lblStart = null!;
+        private NumericUpDown numStart = null!;
+        private Label lblFull = null!;
+        private NumericUpDown numFull = null!;
+        private Label lblFps = null!;
+        private NumericUpDown numFps = null!;
+
+        private Label lblDuration = null!;
+        private NumericUpDown numDuration = null!;
+        private Label lblRefraction = null!;
+        private NumericUpDown numRefraction = null!;
+        private Label lblWobble = null!;
+        private NumericUpDown numWobble = null!;
+
+        private Label lblFadeOut = null!;
+        private NumericUpDown numFadeOut = null!;
+        private Label lblBubbleSize = null!;
+        private NumericUpDown numBubbleSize = null!;
+        private Label lblLayers = null!;
+        private NumericUpDown numLayers = null!;
+
+        private CheckBox chkKeepSize = null!;
+        private Button btnOK = null!;
+        private Button btnCancel = null!;
+
+        public WaterDialog(bool gifMode)
+        {
+            _isGif = gifMode;
+            InitializeComponent();
+            cmbGifPlayMode.Visible = gifMode;
+            cmbGifPlayMode.SelectedIndexChanged += (s, e) => RefreshModeEnabled();
+            UpdateUIText();
+            RefreshModeEnabled();
+            ApplyTheme();
+        }
+
+        public WaterSettings BuildSettings(bool isGif)
+        {
+            return new WaterSettings
+            {
+                InputFilePath = txtInputPath.Text,
+                OutputFilePath = txtOutputPath.Text,
+                IsGif = isGif,
+                Fps = (int)numFps.Value,
+                DurationSeconds = (double)numDuration.Value,
+                PlayGifDuringWater = cmbGifPlayMode.SelectedIndex == 0,
+                KeepOriginalSize = chkKeepSize.Checked,
+                Direction = (WaterDirection)cmbDirection.SelectedIndex,
+                StartSeconds = (double)numStart.Value,
+                FullSeconds = (double)numFull.Value,
+                FadeOutSeconds = (double)numFadeOut.Value,
+                RefractionStrength = (double)numRefraction.Value,
+                SurfaceWobble = (double)numWobble.Value,
+                BubbleSize = (double)numBubbleSize.Value,
+                Layers = (int)numLayers.Value,
+            };
+        }
+
+        private void RefreshModeEnabled()
+        {
+            // Duration only drives the frozen / static fill; the play-along mode uses the live GIF length.
+            numDuration.Enabled = !(_isGif && cmbGifPlayMode.SelectedIndex == 0);
+        }
+
+        private void UpdateUIText()
+        {
+            Text = Resources.WaterDialog_Title;
+            lblInput.Text = Resources.QuickDialog_InputLabel;
+            lblOutput.Text = Resources.QuickDialog_OutputLabel;
+            lblDirection.Text = Resources.WaterDialog_Direction;
+            lblStart.Text = Resources.Dialog_StartSeconds;
+            lblFull.Text = Resources.WaterDialog_FullSeconds;
+            lblFps.Text = Resources.SlotDialog_Fps;
+            lblDuration.Text = Resources.QuickDialog_Duration;
+            lblRefraction.Text = Resources.WaterDialog_Refraction;
+            lblWobble.Text = Resources.WaterDialog_Wobble;
+            lblFadeOut.Text = Resources.WaterDialog_FadeOut;
+            lblBubbleSize.Text = Resources.WaterDialog_BubbleSize;
+            lblLayers.Text = Resources.WaterDialog_Layers;
+            chkKeepSize.Text = Resources.Dialog_KeepOriginalSize;
+            btnBrowseInput.Text = Resources.Button_Browse;
+            btnBrowseOutput.Text = Resources.Button_Browse;
+            btnOK.Text = Resources.ScrollDialog_OK;
+            btnCancel.Text = Resources.ScrollDialog_Cancel;
+
+            int dirSel = cmbDirection.SelectedIndex < 0 ? 0 : cmbDirection.SelectedIndex;
+            cmbDirection.Items.Clear();
+            cmbDirection.Items.Add(Resources.WaterDir_Up);
+            cmbDirection.Items.Add(Resources.WaterDir_Down);
+            cmbDirection.Items.Add(Resources.WaterDir_Left);
+            cmbDirection.Items.Add(Resources.WaterDir_Right);
+            cmbDirection.SelectedIndex = dirSel;
+
+            int playSel = cmbGifPlayMode.SelectedIndex < 0 ? 0 : cmbGifPlayMode.SelectedIndex;
+            cmbGifPlayMode.Items.Clear();
+            cmbGifPlayMode.Items.Add(Resources.WaterDialog_GifPlayDuring);
+            cmbGifPlayMode.Items.Add(Resources.WaterDialog_GifFreeze);
+            cmbGifPlayMode.SelectedIndex = playSel;
+        }
+
+        private void ApplyTheme()
+        {
+            bool isDark = WindowsThemeManager.IsDarkModeEnabled();
+            if (isDark)
+            {
+                BackColor = Color.FromArgb(32, 32, 32);
+                ForeColor = Color.White;
+                ApplyDarkThemeToControls(Controls);
+            }
+            else
+            {
+                BackColor = SystemColors.Control;
+                ForeColor = SystemColors.ControlText;
+                ApplyLightThemeToControls(Controls);
+            }
+
+            if (IsHandleCreated)
+            {
+                WindowsThemeManager.SetDarkModeForWindow(Handle, isDark);
+            }
+        }
+
+        protected override void SetVisibleCore(bool value)
+        {
+            base.SetVisibleCore(value);
+            if (value && IsHandleCreated)
+            {
+                WindowsThemeManager.SetDarkModeForWindow(Handle, WindowsThemeManager.IsDarkModeEnabled());
+            }
+        }
+
+        private void ApplyDarkThemeToControls(Control.ControlCollection controls)
+        {
+            foreach (Control control in controls)
+            {
+                if (control is Label || control is CheckBox)
+                {
+                    control.BackColor = Color.Transparent;
+                    control.ForeColor = Color.White;
+                }
+                else if (control is TextBox textBox)
+                {
+                    textBox.BackColor = Color.FromArgb(64, 64, 64);
+                    textBox.ForeColor = Color.White;
+                }
+                else if (control is Button button)
+                {
+                    button.BackColor = Color.FromArgb(64, 64, 64);
+                    button.ForeColor = Color.White;
+                    button.FlatStyle = FlatStyle.Flat;
+                    button.FlatAppearance.BorderColor = Color.FromArgb(128, 128, 128);
+                }
+                else if (control is NumericUpDown numericUpDown)
+                {
+                    numericUpDown.BackColor = Color.FromArgb(64, 64, 64);
+                    numericUpDown.ForeColor = Color.White;
+                }
+                else if (control is ComboBox comboBox)
+                {
+                    comboBox.BackColor = Color.FromArgb(64, 64, 64);
+                    comboBox.ForeColor = Color.White;
+                }
+
+                if (control.HasChildren)
+                {
+                    ApplyDarkThemeToControls(control.Controls);
+                }
+            }
+        }
+
+        private void ApplyLightThemeToControls(Control.ControlCollection controls)
+        {
+            foreach (Control control in controls)
+            {
+                if (control is Label || control is CheckBox)
+                {
+                    control.BackColor = Color.Transparent;
+                    control.ForeColor = SystemColors.ControlText;
+                }
+                else if (control is TextBox textBox)
+                {
+                    textBox.BackColor = SystemColors.Window;
+                    textBox.ForeColor = SystemColors.WindowText;
+                }
+                else if (control is Button button)
+                {
+                    button.BackColor = SystemColors.Control;
+                    button.ForeColor = SystemColors.ControlText;
+                    button.FlatStyle = FlatStyle.Standard;
+                    button.UseVisualStyleBackColor = true;
+                }
+                else if (control is NumericUpDown numericUpDown)
+                {
+                    numericUpDown.BackColor = SystemColors.Window;
+                    numericUpDown.ForeColor = SystemColors.WindowText;
+                }
+                else if (control is ComboBox comboBox)
+                {
+                    comboBox.BackColor = SystemColors.Window;
+                    comboBox.ForeColor = SystemColors.WindowText;
+                }
+
+                if (control.HasChildren)
+                {
+                    ApplyLightThemeToControls(control.Controls);
+                }
+            }
+        }
+
+        private void BtnBrowseInput_Click(object? sender, EventArgs e)
+        {
+            using var ofd = new OpenFileDialog
+            {
+                Filter = _isGif ? Resources.FileDialog_GifAndWebpFilter : Resources.FileDialog_ImageAndGifFilter,
+                Title = Resources.QuickDialog_InputLabel
+            };
+            if (ofd.ShowDialog() == DialogResult.OK)
+            {
+                txtInputPath.Text = ofd.FileName;
+                if (string.IsNullOrWhiteSpace(txtOutputPath.Text))
+                {
+                    string dir = Path.GetDirectoryName(ofd.FileName) ?? string.Empty;
+                    string name = Path.GetFileNameWithoutExtension(ofd.FileName) + "_water.gif";
+                    txtOutputPath.Text = Path.Combine(dir, name);
+                }
+            }
+        }
+
+        private void BtnBrowseOutput_Click(object? sender, EventArgs e)
+        {
+            using var sfd = new SaveFileDialog
+            {
+                Filter = Resources.FileDialog_GifFilter,
+                Title = Resources.QuickDialog_OutputLabel,
+                FileName = string.IsNullOrEmpty(txtInputPath.Text)
+                    ? "output_water.gif"
+                    : Path.GetFileNameWithoutExtension(txtInputPath.Text) + "_water.gif"
+            };
+            if (sfd.ShowDialog() == DialogResult.OK)
+            {
+                txtOutputPath.Text = sfd.FileName;
+            }
+        }
+
+        private void BtnOK_Click(object? sender, EventArgs e)
+        {
+            if (string.IsNullOrWhiteSpace(txtInputPath.Text) || !File.Exists(txtInputPath.Text))
+            {
+                MessageBox.Show(this, Resources.ScrollDialog_InputRequired, Resources.Title_Error, MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                return;
+            }
+            if (string.IsNullOrWhiteSpace(txtOutputPath.Text))
+            {
+                MessageBox.Show(this, Resources.ScrollDialog_OutputRequired, Resources.Title_Error, MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                return;
+            }
+            DialogResult = DialogResult.OK;
+            Close();
+        }
+
+        private static NumericUpDown MakeNum(int x, int y, int width, int decimals, decimal min, decimal max, decimal inc, decimal val)
+        {
+            var n = new NumericUpDown
+            {
+                Location = new Point(x, y),
+                Size = new Size(width, 23),
+                DecimalPlaces = decimals,
+            };
+            n.Minimum = min;
+            n.Maximum = max;
+            n.Increment = inc;
+            n.Value = val;
+            return n;
+        }
+
+        private void InitializeComponent()
+        {
+            lblInput = new Label { Location = new Point(14, 9), Size = new Size(360, 20), Text = "Input" };
+            txtInputPath = new TextBox { Location = new Point(14, 29), Size = new Size(418, 23), ReadOnly = true };
+            btnBrowseInput = new Button { Location = new Point(440, 27), Size = new Size(86, 25), Text = "Browse", UseVisualStyleBackColor = true };
+            btnBrowseInput.Click += BtnBrowseInput_Click;
+            lblOutput = new Label { Location = new Point(14, 58), Size = new Size(360, 20), Text = "Output" };
+            txtOutputPath = new TextBox { Location = new Point(14, 78), Size = new Size(418, 23), ReadOnly = true };
+            btnBrowseOutput = new Button { Location = new Point(440, 76), Size = new Size(86, 25), Text = "Browse", UseVisualStyleBackColor = true };
+            btnBrowseOutput.Click += BtnBrowseOutput_Click;
+
+            // Direction + playback-mode row
+            lblDirection = new Label { Location = new Point(14, 116), Size = new Size(40, 20), Text = "Dir" };
+            cmbDirection = new ComboBox { Location = new Point(56, 114), Size = new Size(100, 23), DropDownStyle = ComboBoxStyle.DropDownList };
+            cmbGifPlayMode = new ComboBox { Location = new Point(280, 114), Size = new Size(200, 23), DropDownStyle = ComboBoxStyle.DropDownList };
+
+            // Timing row
+            lblStart = new Label { Location = new Point(14, 149), Size = new Size(70, 20), Text = "Start" };
+            numStart = MakeNum(116, 147, 56, 2, 0.00m, 120.00m, 0.25m, 0.50m);
+            lblFull = new Label { Location = new Point(178, 149), Size = new Size(84, 20), Text = "Full level" };
+            numFull = MakeNum(268, 147, 56, 2, 0.10m, 120.00m, 0.25m, 4.00m);
+            lblFps = new Label { Location = new Point(338, 149), Size = new Size(34, 20), Text = "FPS" };
+            numFps = MakeNum(374, 147, 46, 0, 5m, 60m, 1m, 20m);
+
+            // Look row 1
+            lblDuration = new Label { Location = new Point(14, 182), Size = new Size(100, 20), Text = "Duration" };
+            numDuration = MakeNum(116, 180, 56, 2, 0.10m, 120.00m, 0.25m, 6.00m);
+            lblRefraction = new Label { Location = new Point(178, 182), Size = new Size(46, 20), Text = "Refract" };
+            numRefraction = MakeNum(228, 180, 56, 1, 0.0m, 30.0m, 0.5m, 4.0m);
+            lblWobble = new Label { Location = new Point(290, 182), Size = new Size(70, 20), Text = "Wobble" };
+            numWobble = MakeNum(364, 180, 56, 1, 0.0m, 40.0m, 0.5m, 6.0m);
+
+            // Look row 2 (bubble size + layers + fade-out; bubble count is automatic)
+            lblBubbleSize = new Label { Location = new Point(14, 215), Size = new Size(72, 20), Text = "Bubble size" };
+            numBubbleSize = MakeNum(88, 213, 56, 1, 2.0m, 60.0m, 1.0m, 12.0m);
+            lblLayers = new Label { Location = new Point(154, 215), Size = new Size(46, 20), Text = "Layers" };
+            numLayers = MakeNum(202, 213, 46, 0, 1m, 8m, 1m, 3m);
+            lblFadeOut = new Label { Location = new Point(260, 215), Size = new Size(88, 20), Text = "Fade out (s)" };
+            numFadeOut = MakeNum(350, 213, 56, 2, 0.00m, 30.00m, 0.25m, 0.50m);
+
+            chkKeepSize = new CheckBox { Location = new Point(14, 247), Size = new Size(340, 22), Text = "Keep original size", UseVisualStyleBackColor = true };
+
+            btnOK = new Button { Location = new Point(363, 283), Size = new Size(75, 25), Text = "OK", UseVisualStyleBackColor = true };
+            btnOK.Click += BtnOK_Click;
+            btnCancel = new Button { Location = new Point(444, 283), Size = new Size(82, 25), Text = "Cancel", DialogResult = DialogResult.Cancel, UseVisualStyleBackColor = true };
+
+            SuspendLayout();
+            Controls.Add(lblInput);
+            Controls.Add(txtInputPath);
+            Controls.Add(btnBrowseInput);
+            Controls.Add(lblOutput);
+            Controls.Add(txtOutputPath);
+            Controls.Add(btnBrowseOutput);
+            Controls.Add(lblDirection);
+            Controls.Add(cmbDirection);
+            Controls.Add(cmbGifPlayMode);
+            Controls.Add(lblStart);
+            Controls.Add(numStart);
+            Controls.Add(lblFull);
+            Controls.Add(numFull);
+            Controls.Add(lblFps);
+            Controls.Add(numFps);
+            Controls.Add(lblDuration);
+            Controls.Add(numDuration);
+            Controls.Add(lblRefraction);
+            Controls.Add(numRefraction);
+            Controls.Add(lblWobble);
+            Controls.Add(numWobble);
+            Controls.Add(lblFadeOut);
+            Controls.Add(numFadeOut);
+            Controls.Add(lblBubbleSize);
+            Controls.Add(numBubbleSize);
+            Controls.Add(lblLayers);
+            Controls.Add(numLayers);
+            Controls.Add(chkKeepSize);
+            Controls.Add(btnOK);
+            Controls.Add(btnCancel);
+
+            AutoScaleDimensions = new SizeF(7F, 15F);
+            AutoScaleMode = AutoScaleMode.Font;
+            CancelButton = btnCancel;
+            AcceptButton = btnOK;
+            ClientSize = new Size(540, 322);
+            FormBorderStyle = FormBorderStyle.FixedDialog;
+            MaximizeBox = false;
+            MinimizeBox = false;
+            Name = "WaterDialog";
+            StartPosition = FormStartPosition.CenterParent;
+            Text = "Water Fill";
+            ResumeLayout(false);
+            PerformLayout();
+        }
+    }
+}

--- a/src/Forms/GTMainForm.Designer.cs
+++ b/src/Forms/GTMainForm.Designer.cs
@@ -86,6 +86,8 @@
             btnWindGif = new System.Windows.Forms.Button();
             btnRainStatic = new System.Windows.Forms.Button();
             btnRainGif = new System.Windows.Forms.Button();
+            btnWaterStatic = new System.Windows.Forms.Button();
+            btnWaterGif = new System.Windows.Forms.Button();
             btnMorphTransition = new System.Windows.Forms.Button();
             chkAutoFitSplit = new System.Windows.Forms.CheckBox();
             numUpDownTargetKB = new System.Windows.Forms.NumericUpDown();
@@ -153,7 +155,7 @@
             // pBarTaskStatus
             // 
             pBarTaskStatus.Dock = System.Windows.Forms.DockStyle.Bottom;
-            pBarTaskStatus.Location = new System.Drawing.Point(0, 596);
+            pBarTaskStatus.Location = new System.Drawing.Point(0, 627);
             pBarTaskStatus.Margin = new System.Windows.Forms.Padding(2);
             pBarTaskStatus.Name = "pBarTaskStatus";
             pBarTaskStatus.Size = new System.Drawing.Size(619, 20);
@@ -162,7 +164,7 @@
             // lblStatus
             // 
             lblStatus.Dock = System.Windows.Forms.DockStyle.Bottom;
-            lblStatus.Location = new System.Drawing.Point(0, 581);
+            lblStatus.Location = new System.Drawing.Point(0, 612);
             lblStatus.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             lblStatus.Name = "lblStatus";
             lblStatus.Size = new System.Drawing.Size(619, 15);
@@ -215,7 +217,7 @@
             panelGifsicle.Controls.Add(numUpDownPalette);
             panelGifsicle.Controls.Add(lblPaletteDesc);
             panelGifsicle.Dock = System.Windows.Forms.DockStyle.Bottom;
-            panelGifsicle.Location = new System.Drawing.Point(0, 462);
+            panelGifsicle.Location = new System.Drawing.Point(0, 493);
             panelGifsicle.Margin = new System.Windows.Forms.Padding(2);
             panelGifsicle.Name = "panelGifsicle";
             panelGifsicle.Size = new System.Drawing.Size(619, 175);
@@ -503,7 +505,7 @@
             // lblFramerate
             // 
             lblFramerate.AutoSize = true;
-            lblFramerate.Location = new System.Drawing.Point(11, 439);
+            lblFramerate.Location = new System.Drawing.Point(11, 470);
             lblFramerate.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             lblFramerate.Name = "lblFramerate";
             lblFramerate.Size = new System.Drawing.Size(0, 15);
@@ -512,7 +514,7 @@
             // lblFPS
             // 
             lblFPS.AutoSize = true;
-            lblFPS.Location = new System.Drawing.Point(310, 439);
+            lblFPS.Location = new System.Drawing.Point(310, 470);
             lblFPS.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             lblFPS.Name = "lblFPS";
             lblFPS.Size = new System.Drawing.Size(0, 15);
@@ -540,7 +542,7 @@
             // 
             // btnLanguageChange
             // 
-            btnLanguageChange.Location = new System.Drawing.Point(548, 411);
+            btnLanguageChange.Location = new System.Drawing.Point(548, 442);
             btnLanguageChange.Name = "btnLanguageChange";
             btnLanguageChange.Size = new System.Drawing.Size(64, 26);
             btnLanguageChange.TabIndex = 16;
@@ -618,7 +620,7 @@
             // lblResourceLimitDesc
             // 
             lblResourceLimitDesc.AutoSize = true;
-            lblResourceLimitDesc.Location = new System.Drawing.Point(7, 413);
+            lblResourceLimitDesc.Location = new System.Drawing.Point(7, 444);
             lblResourceLimitDesc.Name = "lblResourceLimitDesc";
             lblResourceLimitDesc.Size = new System.Drawing.Size(234, 15);
             lblResourceLimitDesc.TabIndex = 15;
@@ -626,7 +628,7 @@
             // 
             // numUpDownFramerate
             // 
-            numUpDownFramerate.Location = new System.Drawing.Point(255, 437);
+            numUpDownFramerate.Location = new System.Drawing.Point(255, 468);
             numUpDownFramerate.Margin = new System.Windows.Forms.Padding(2);
             numUpDownFramerate.Maximum = new decimal(new int[] { 30, 0, 0, 0 });
             numUpDownFramerate.Minimum = new decimal(new int[] { 5, 0, 0, 0 });
@@ -755,12 +757,32 @@
             btnRainGif.UseVisualStyleBackColor = true;
             btnRainGif.Click += btnRainGif_Click;
             //
+            // btnWaterStatic
+            //
+            btnWaterStatic.Location = new System.Drawing.Point(7, 379);
+            btnWaterStatic.Name = "btnWaterStatic";
+            btnWaterStatic.Size = new System.Drawing.Size(300, 26);
+            btnWaterStatic.TabIndex = 30;
+            btnWaterStatic.Text = SteamGifCropper.Properties.Resources.Button_WaterStatic;
+            btnWaterStatic.UseVisualStyleBackColor = true;
+            btnWaterStatic.Click += btnWaterStatic_Click;
+            //
+            // btnWaterGif
+            //
+            btnWaterGif.Location = new System.Drawing.Point(313, 379);
+            btnWaterGif.Name = "btnWaterGif";
+            btnWaterGif.Size = new System.Drawing.Size(300, 26);
+            btnWaterGif.TabIndex = 31;
+            btnWaterGif.Text = SteamGifCropper.Properties.Resources.Button_WaterGif;
+            btnWaterGif.UseVisualStyleBackColor = true;
+            btnWaterGif.Click += btnWaterGif_Click;
+            //
             // btnMorphTransition
             //
-            btnMorphTransition.Location = new System.Drawing.Point(7, 379);
+            btnMorphTransition.Location = new System.Drawing.Point(7, 410);
             btnMorphTransition.Name = "btnMorphTransition";
             btnMorphTransition.Size = new System.Drawing.Size(606, 26);
-            btnMorphTransition.TabIndex = 29;
+            btnMorphTransition.TabIndex = 32;
             btnMorphTransition.Text = SteamGifCropper.Properties.Resources.Button_MorphTransition;
             btnMorphTransition.UseVisualStyleBackColor = true;
             btnMorphTransition.Click += btnMorphTransition_Click;
@@ -770,7 +792,7 @@
             AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
             AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
-            ClientSize = new System.Drawing.Size(619, 680);
+            ClientSize = new System.Drawing.Size(619, 711);
             Controls.Add(lblResourceLimitDesc);
             Controls.Add(btnResizeNfpsGIF);
             Controls.Add(btnOverlayGIF);
@@ -803,6 +825,8 @@
             Controls.Add(btnWindGif);
             Controls.Add(btnRainStatic);
             Controls.Add(btnRainGif);
+            Controls.Add(btnWaterStatic);
+            Controls.Add(btnWaterGif);
             Controls.Add(btnMorphTransition);
             Icon = (System.Drawing.Icon)resources.GetObject("$this.Icon");
             Margin = new System.Windows.Forms.Padding(2);
@@ -886,6 +910,8 @@
         private System.Windows.Forms.Button btnWindGif;
         private System.Windows.Forms.Button btnRainStatic;
         private System.Windows.Forms.Button btnRainGif;
+        private System.Windows.Forms.Button btnWaterStatic;
+        private System.Windows.Forms.Button btnWaterGif;
         private System.Windows.Forms.Button btnMorphTransition;
         public System.Windows.Forms.CheckBox chkAutoFitSplit;
         public System.Windows.Forms.NumericUpDown numUpDownTargetKB;

--- a/src/Forms/GTMainForm.cs
+++ b/src/Forms/GTMainForm.cs
@@ -279,6 +279,16 @@ namespace GifProcessorApp
             await ExecuteWithErrorHandling(async () => await GifProcessor.RainGif(this), "rain overlay (GIF)");
         }
 
+        private async void btnWaterStatic_Click(object sender, EventArgs e)
+        {
+            await ExecuteWithErrorHandling(async () => await GifProcessor.WaterStaticImage(this), "water fill (image)");
+        }
+
+        private async void btnWaterGif_Click(object sender, EventArgs e)
+        {
+            await ExecuteWithErrorHandling(async () => await GifProcessor.WaterGif(this), "water fill (GIF)");
+        }
+
         private async void btnMorphTransition_Click(object sender, EventArgs e)
         {
             await ExecuteWithErrorHandling(async () => await GifProcessor.MorphTransition(this), "morph transition (A→B)");


### PR DESCRIPTION
## Summary
A **fill with water + rising bubbles** effect, in two places sharing one core (`WaterField` pure + `WaterRenderer` Magick, above/below parameterized). Field-tested and revised per feedback.

- **Main-UI effect** (`Water Fill` image / GIF buttons): water rises from a chosen direction; **below the wavy surface** the image is refracted and seen through rising lensing bubbles, **above** it is unchanged. Once full, the **whole effect fades out** (fade-out seconds) back to the plain source. Play-along (fills over the playing GIF, then plain) / frozen-then-play.
- **A→B morph style** (6th): below the surface shows **GIF B**, above shows **GIF A**; the fill follows the morph window (full B at t=1).

## Behaviour from testing feedback
- Effect **fully fades out** after the tank is full (refraction + bubbles), then the source returns to normal.
- Bubbles **never hard-clip at the surface** — they rise slowly, **sway left-right**, **swell near the surface** (pressure), and **fade out before the waterline** (the "diver's exhaled bubbles" look).
- Bubble **count is automatic** (modest, by canvas area) — the setting was removed and replaced with **fade-out seconds**.

## Implementation
- Pure math (`WaterField`: fill fraction, wavy surface, underwater test for 4 directions, shimmer, bubble schedule + lens, `EffectAlpha`, `AutoBubbleCount`) linked into the test project; `WaterRenderer` does the above/below sampling + bubble lens/rim/highlight + the fade blend.
- `MorphStyle.WaterFill`, engine dispatch, dialog water group; main form `btnWaterStatic`/`btnWaterGif` (+31px row, `ClientSize` 711). ~19 localized strings (en/zh-TW/ja + Designer).

## Testing
- `dotnet build SteamGifCropper.sln` → 0 warnings / 0 errors.
- Full xUnit suite: **258 tests, 0 failures** (`WaterFieldTests` + water renderer smoke).
- User field-tested both the effect and the revisions in the app.

Note: water rendering is heavier than the other effects (per-pixel sampling + bubble passes); the 766px fit keeps it reasonable and the large-canvas warning still applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)